### PR TITLE
Huge revamp of the whole addon

### DIFF
--- a/addon.json
+++ b/addon.json
@@ -1,7 +1,7 @@
 {
-	"title"		:	"MSync - Keep everythng synchronised",
+	"title"		:	"MSync - Keep everything synchronised",
 	"type"		:	"ServerContent",
-	"tags"		:	[ "fun","build" ],
+	"tags"		:	["fun", "build"],
 	"ignore"	:
 	[
 		"*.psd",

--- a/lua/autorun/client/cl_msync_util.lua
+++ b/lua/autorun/client/cl_msync_util.lua
@@ -3,7 +3,7 @@ if CLIENT then
 	--Declaring MSync Variable
 	MSync = MSync or {}
 	MSync.RFP = false
-	MSync.LocalSettings = MSync.LocalSettings or { --Set MSync.LocalSettings to MSync.LocalSettings or to Default Settings to Prevent Empty MSync.LocalSettings
+	MSync.LocalSettings = MSync.LocalSettings or { //Set MSync.LocalSettings to MSync.LocalSettings or to Default Settings to Prevent Empty MSync.LocalSettings
 			Servergroup = "Default",
 			EnabledModules = {
 				"MRSync"

--- a/lua/autorun/client/cl_msync_util.lua
+++ b/lua/autorun/client/cl_msync_util.lua
@@ -1,11 +1,12 @@
 -- TODO encapsulate os.date() formatting
 
 if CLIENT then
-	print("loaded")
-	--Declaring MSync Variable
+	print("[MSync] Loaded")
+	-- Declaring MSync Variable
 	MSync = MSync or {}
 	MSync.RFP = false
-	MSync.LocalSettings = MSync.LocalSettings or { //Set MSync.LocalSettings to MSync.LocalSettings or to Default Settings to Prevent Empty MSync.LocalSettings
+	-- TODO move this away into some shared file
+	MSync.LocalSettings = MSync.LocalSettings or { -- Set MSync.LocalSettings to MSync.LocalSettings or to Default Settings to Prevent Empty MSync.LocalSettings
 			Servergroup = "Default",
 			EnabledModules = {
 				"MRSync"
@@ -30,30 +31,31 @@ if CLIENT then
 					"drp_donator",
 					"drp_admin"
 				}
-			}
+			},
+			DBVersion = 0
 	}
-	
-	--##NET RECIEVER##
-	
+
+	-- ##NET RECIEVER##
+
 	net.Receive("MSyncRevertSettings", function( len, ply )
 			MSync.Chat(Color(255,255,255),"Retrieved data from server! (A1)")
 			MSync.LocalSettings = net.ReadTable()
 			MSync.RefreshPanel()
-			
+
 	end)
-	
+
 	net.Receive("MSyncChatPrint", function( len, ply )
-			MSync.Chat(net.ReadColor() ,net.ReadString())		
+			MSync.Chat(net.ReadColor() ,net.ReadString())
 	end)
-	
+
 	net.Receive("MSyncRevertBans", function( len, ply )
 			MSync.Chat(Color(255,255,255),"Retrieved bans from server! (A1)")
 			MSync.LocalBans = net.ReadTable()
 			AddBanTable()
-			
+
 	end)
-	--##NET TRANSMITTER FUNCTIONS##
-	
+	-- ##NET TRANSMITTER FUNCTIONS##
+
 	function MSync.SendSettings()
 		MSync.Chat(Color(255,255,255),"Sending data to server! (A1)")
 		net.Start( "MSyncTableSend" )
@@ -61,23 +63,23 @@ if CLIENT then
 			net.WriteEntity( LocalPlayer() )
 		net.SendToServer()
 	end
-	
+
 	function MSync.GetBans()
 		MSync.Chat(Color(255,255,255),"Retrieving bans from server! (A1)")
 		net.Start( "MSyncGetBans" )
 			net.WriteEntity( LocalPlayer() )
 		net.SendToServer()
 	end
-	
+
 	function MSync.GetSettings()
 		MSync.Chat(Color(255,255,255),"Retrieving data from server! (A1)")
 		net.Start( "MSyncGetSettings" )
 			net.WriteEntity( LocalPlayer() )
 		net.SendToServer()
-	end	
-	
-	--##XGUI FUNCTIONS##
-	
+	end
+
+	-- ##XGUI FUNCTIONS##
+
 	function MSync.RefreshPanel()
 		if not(MSync.RFP)then
 			MSync.MySQL.init()
@@ -90,7 +92,7 @@ if CLIENT then
 			HidePanel(MSync.MySQL)
 			MSync.settingList:Clear()
 			MSync.settingList:AddLine( "MySQL" )
-			MSync.settingList:AddLine( "Modules" ) 
+			MSync.settingList:AddLine( "Modules" )
 			AddTable(MSync.LocalSettings.EnabledModules,MSync.settingList)
 			MSync.Modules.enabledModulesList:Clear()
 			MSync.Modules.disabledModulesList:Clear()
@@ -110,7 +112,7 @@ if CLIENT then
 			MSync.MySQL.Servergrp:SetText(MSync.LocalSettings.Servergroup)
 			MSync.settingList:Clear()
 			MSync.settingList:AddLine( "MySQL" )
-			MSync.settingList:AddLine( "Modules" ) 
+			MSync.settingList:AddLine( "Modules" )
 			AddTable(MSync.LocalSettings.EnabledModules,MSync.settingList)
 			MSync.Modules.enabledModulesList:Clear()
 			MSync.Modules.disabledModulesList:Clear()
@@ -122,9 +124,9 @@ if CLIENT then
 			AddTable(MSync.LocalSettings.mrsync.AllServerRanks,MSync.MRSync.AllServerTable)
 		end
 	end
-	
-	--##UTIL FUNCTIONS##
-	
+
+	-- ##UTIL FUNCTIONS##
+
 	function MSync.Chat(col, text)
 		chat.AddText(Color(255,255,255),"[",Color(120,0,0),"MSync",Color(255,255,255),"]",col,text)
 	end
@@ -152,7 +154,7 @@ if CLIENT then
 			end
 		end
 	end
-	
+
 	function AddBanTable()
 		MSync.MBSync.Table:Clear()
 		for k, v in pairs( MSync.LocalBans ) do
@@ -165,7 +167,7 @@ if CLIENT then
 			end
 		end
 	end
-	
+
 	function MSync.BanTableUnban(term)
 		if not (ULib.isValidSteamID(term)) then
 			for k, v in pairs( MSync.LocalBans ) do
@@ -177,7 +179,7 @@ if CLIENT then
 			RunConsoleCommand("ulx","unban",term )
 		end
 	end
-	
+
 	function SearchBanTable(searchterm)
 		MSync.MBSync.Table:Clear()
 		if(ULib.isValidSteamID(string.upper( searchterm )))then
@@ -195,5 +197,5 @@ if CLIENT then
 		end
 	end
 
-	
+
 end

--- a/lua/autorun/client/cl_msync_util.lua
+++ b/lua/autorun/client/cl_msync_util.lua
@@ -1,3 +1,5 @@
+-- TODO encapsulate os.date() formatting
+
 if CLIENT then
 	print("loaded")
 	--Declaring MSync Variable
@@ -34,7 +36,7 @@ if CLIENT then
 	--##NET RECIEVER##
 	
 	net.Receive("MSyncRevertSettings", function( len, ply )
-			MSync.Chat(Color(255,255,255),"Retrived Data from Server! (A1)")
+			MSync.Chat(Color(255,255,255),"Retrieved data from server! (A1)")
 			MSync.LocalSettings = net.ReadTable()
 			MSync.RefreshPanel()
 			
@@ -45,7 +47,7 @@ if CLIENT then
 	end)
 	
 	net.Receive("MSyncRevertBans", function( len, ply )
-			MSync.Chat(Color(255,255,255),"Retrived Bans from Server! (A1)")
+			MSync.Chat(Color(255,255,255),"Retrieved bans from server! (A1)")
 			MSync.LocalBans = net.ReadTable()
 			AddBanTable()
 			
@@ -53,7 +55,7 @@ if CLIENT then
 	--##NET TRANSMITTER FUNCTIONS##
 	
 	function MSync.SendSettings()
-		MSync.Chat(Color(255,255,255),"Sending Data to Server! (A1)")
+		MSync.Chat(Color(255,255,255),"Sending data to server! (A1)")
 		net.Start( "MSyncTableSend" )
 			net.WriteTable( MSync.LocalSettings )
 			net.WriteEntity( LocalPlayer() )
@@ -61,14 +63,14 @@ if CLIENT then
 	end
 	
 	function MSync.GetBans()
-		MSync.Chat(Color(255,255,255),"Getting Bans from Server! (A1)")
+		MSync.Chat(Color(255,255,255),"Retrieving bans from server! (A1)")
 		net.Start( "MSyncGetBans" )
 			net.WriteEntity( LocalPlayer() )
 		net.SendToServer()
 	end
 	
 	function MSync.GetSettings()
-		MSync.Chat(Color(255,255,255),"Retriving Data from Server! (A1)")
+		MSync.Chat(Color(255,255,255),"Retrieving data from server! (A1)")
 		net.Start( "MSyncGetSettings" )
 			net.WriteEntity( LocalPlayer() )
 		net.SendToServer()

--- a/lua/autorun/server/sv_msync_modules.lua
+++ b/lua/autorun/server/sv_msync_modules.lua
@@ -1,4 +1,6 @@
-//#############################################
-//##THIS FILE IS JUST FOR THE CASE THAT THERE##
-//####IS A NEW MSYNC MODULE WHICH GOT ADDED####
-//#############################################
+--[[
+#############################################
+##THIS FILE IS JUST FOR THE CASE THAT THERE##
+####IS A NEW MSYNC MODULE WHICH GOT ADDED####
+#############################################
+]]--

--- a/lua/autorun/server/sv_msync_modules.lua
+++ b/lua/autorun/server/sv_msync_modules.lua
@@ -1,6 +1,4 @@
---[[
-#############################################
-##THIS FILE IS JUST FOR THE CASE THAT THERE##
-####IS A NEW MSYNC MODULE WHICH GOT ADDED####
-#############################################
-]]--
+//#############################################
+//##THIS FILE IS JUST FOR THE CASE THAT THERE##
+//####IS A NEW MSYNC MODULE WHICH GOT ADDED####
+//#############################################

--- a/lua/autorun/server/sv_msync_util.lua
+++ b/lua/autorun/server/sv_msync_util.lua
@@ -12,7 +12,7 @@ concommand.Add( "msync_version", function( ply, cmd, args )
 	print("[MSync] Version: \nMSync version: "..MSync.version.." \nMBSync version: "..MSync.MBsyncVersion.." \nMRSync version: "..MSync.MRsyncVersion.." \nMSync XGUI version: "..MSync.xgui_panelVersion)
 end )
 
---Load Function on Enable of the Addon
+//Load Function on Enable of the Addon
 function MSync.load()
 
 	if not (file.Exists( "msync/settings.txt", "DATA" ))then
@@ -72,11 +72,11 @@ function MSync.SaveSettings()
 	file.Write( "msync/settings.txt", util.TableToJSON( MSync.Settings, true ))
 end
 
---Read Groups for Permissions
+//Read Groups for Permissions
 
 
 
---Send Settings to Players
+//Send Settings to Players
 net.Receive("MSyncGetSettings", function( len, ply )
 			
 			local plygroup = ply:GetUserGroup()
@@ -91,7 +91,7 @@ net.Receive("MSyncGetSettings", function( len, ply )
 			
 end)
 
---Get The Ban Table
+//Get The Ban Table
 net.Receive("MSyncGetBans", function( len, ply )
 			
 			local plygroup = ply:GetUserGroup()
@@ -106,7 +106,7 @@ net.Receive("MSyncGetBans", function( len, ply )
 			end
 			
 end)
---Get Table and save the Settings
+//Get Table and save the Settings
 net.Receive("MSyncTableSend", function( len, ply )
 
 		local plygroup = ply:GetUserGroup()

--- a/lua/autorun/server/sv_msync_util.lua
+++ b/lua/autorun/server/sv_msync_util.lua
@@ -9,14 +9,20 @@ MSync.MRsyncVersion = "A 1.3"
 MSync.xgui_panelVersion = "A 1.5"
 
 concommand.Add( "msync_version", function( ply, cmd, args )
-	print("[MSync] Version: \nMSync version: "..MSync.version.." \nMBSync version: "..MSync.MBsyncVersion.." \nMRSync version: "..MSync.MRsyncVersion.." \nMSync XGUI version: "..MSync.xgui_panelVersion)
-end )
+	print(
+		"[MSync] Version:\n" ..
+		"MSync version: " .. MSync.version .. "\n" ..
+		"MBSync version: " .. MSync.MBsyncVersion .. "\n" ..
+		"MRSync version: " .. MSync.MRsyncVersion .. "\n" ..
+		"MSync XGUI version: " .. MSync.xgui_panelVersion
+	)
+end)
 
 //Load Function on Enable of the Addon
 function MSync.load()
 
-	if not (file.Exists( "msync/settings.txt", "DATA" ))then
-		print("[MSync] Writting Settings File")
+	if not (file.Exists( "msync/settings.txt", "DATA" )) then
+		print("[MSync] Writting settings file")
 		file.CreateDir( "msync" )
 		
 		MSync.Settings = {
@@ -50,7 +56,7 @@ function MSync.load()
 		file.Write( "msync/settings.txt", util.TableToJSON( MSync.Settings, true ))
 		
 	elseif(file.Exists( "msync/settings.txt", "DATA" ))then
-		print("[MSync] Getting Settings File")
+		print("[MSync] Getting settings file")
 		MSync.Settings = util.JSONToTable( file.Read( "msync/settings.txt", "DATA" ))
 		
 	end
@@ -75,18 +81,19 @@ end
 //Read Groups for Permissions
 
 
+-- TODO duplicate code here
 
 //Send Settings to Players
 net.Receive("MSyncGetSettings", function( len, ply )
 			
 			local plygroup = ply:GetUserGroup()
-			if(ULib.ucl.query(ply,"xgui_msync"))then
+			if(ULib.ucl.query(ply,"xgui_msync")) then
 				net.Start("MSyncRevertSettings")
 					net.WriteTable( MSync.Settings )
 				net.Send(ply)
 			else
-				MSync.SendMessageToAdmins(Color(255,255,255),"WARNING: Player: "..ply:GetName().." Tryed to Exploit the Server and got Kicked! (A2)")
-				ply:Kick( "[MSync] CSLua: Tryed to Force get Server Settings Table (A2)" )
+				MSync.SendMessageToAdmins(Color(255,255,255),"WARNING: Player: "..ply:GetName().." tried to exploit the server and got kicked! (A2)")
+				ply:Kick( "[MSync] CSLua: Tried to force-get server settings table (A2)" )
 			end
 			
 end)
@@ -101,8 +108,8 @@ net.Receive("MSyncGetBans", function( len, ply )
 					net.WriteTable( MSync.Bans )
 				net.Send(ply)
 			else
-				MSync.SendMessageToAdmins(Color(255,255,255),"WARNING: Player: "..ply:GetName().." Tryed to Exploit the Server and got Kicked! (A2)")
-				ply:Kick( "[MSync] CSLua: Tryed to Force get Server Settings Table (A2)" )
+				MSync.SendMessageToAdmins(Color(255,255,255),"WARNING: Player: "..ply:GetName().." tried to exploit the server and got kicked! (A2)")
+				ply:Kick( "[MSync] CSLua: Tried to force get server settings table (A2)" )
 			end
 			
 end)
@@ -114,8 +121,8 @@ net.Receive("MSyncTableSend", function( len, ply )
 			MSync.Settings = net.ReadTable()
 			MSync.SaveSettings()
 		else
-			MSync.SendMessageToAdmins(Color(255,255,255),"WARNING: Player: "..ply:GetName().." Tryed to Exploit the Server and got Kicked! (A2)")
-			ply:Kick( "[MSync] CSLua: Tryed to Force Send Settings Table (A2)" )
+			MSync.SendMessageToAdmins(Color(255,255,255),"WARNING: Player: "..ply:GetName().." tried to exploit the server and got kicked! (A2)")
+			ply:Kick( "[MSync] CSLua: Tried to force-send settings table (A2)" )
 		end
 end)
 

--- a/lua/autorun/server/sv_msync_util.lua
+++ b/lua/autorun/server/sv_msync_util.lua
@@ -4,6 +4,7 @@ MSync.Settings = MSync.Settings or {}
 MSync.ULX = MSync.ULX or {}
 MSync.AllowedGroups = MSync.AllowedGroups or {}
 MSync.version = "A 1.3"
+MSync.DBVersion = 1.3
 MSync.MBsyncVersion = "A 1.0"
 MSync.MRsyncVersion = "A 1.3"
 MSync.xgui_panelVersion = "A 1.5"
@@ -18,13 +19,13 @@ concommand.Add( "msync_version", function( ply, cmd, args )
 	)
 end)
 
-//Load Function on Enable of the Addon
+-- Load Function on Enable of the Addon
 function MSync.load()
 
 	if not (file.Exists( "msync/settings.txt", "DATA" )) then
 		print("[MSync] Writting settings file")
 		file.CreateDir( "msync" )
-		
+
 		MSync.Settings = {
 			Servergroup = "Default",
 			EnabledModules = {
@@ -50,15 +51,15 @@ function MSync.load()
 					"drp_donator",
 					"drp_admin"
 				}
-			}
+			},
+			DBVersion = 0
 		}
-		
+
 		file.Write( "msync/settings.txt", util.TableToJSON( MSync.Settings, true ))
-		
-	elseif(file.Exists( "msync/settings.txt", "DATA" ))then
+
+	else
 		print("[MSync] Getting settings file")
 		MSync.Settings = util.JSONToTable( file.Read( "msync/settings.txt", "DATA" ))
-		
 	end
 
 	util.AddNetworkString( "MSyncRevertSettings" )
@@ -69,7 +70,7 @@ function MSync.load()
 	util.AddNetworkString( "MSyncRevertBans" )
 	include( "autorun/server/sv_msync_modules.lua" )
 	include( "msync/mysql_main.lua" )
-	if(table.HasValue(MSync.Settings.EnabledModules,"MBSync"))then
+	if(table.HasValue(MSync.Settings.EnabledModules,"MBSync")) then
 		MSync.GetBans()
 	end
 end
@@ -78,52 +79,44 @@ function MSync.SaveSettings()
 	file.Write( "msync/settings.txt", util.TableToJSON( MSync.Settings, true ))
 end
 
-//Read Groups for Permissions
-
+-- Read Groups for Permissions
 
 -- TODO duplicate code here
 
-//Send Settings to Players
+-- Send Settings to Players
 net.Receive("MSyncGetSettings", function( len, ply )
-			
-			local plygroup = ply:GetUserGroup()
-			if(ULib.ucl.query(ply,"xgui_msync")) then
-				net.Start("MSyncRevertSettings")
-					net.WriteTable( MSync.Settings )
-				net.Send(ply)
-			else
-				MSync.SendMessageToAdmins(Color(255,255,255),"WARNING: Player: "..ply:GetName().." tried to exploit the server and got kicked! (A2)")
-				ply:Kick( "[MSync] CSLua: Tried to force-get server settings table (A2)" )
-			end
-			
+	if(ULib.ucl.query(ply, "xgui_msync")) then
+		net.Start("MSyncRevertSettings")
+			net.WriteTable(MSync.Settings)
+		net.Send(ply)
+	else
+		MSync.SendMessageToAdmins(Color(255,255,255), "WARNING: Player: " .. ply:GetName() .. " tried to exploit the server and got kicked! (A2)")
+		ply:Kick("[MSync] CSLua: Tried to force-get server settings table (A2)")
+	end
+
 end)
 
-//Get The Ban Table
+-- Get The Ban Table
 net.Receive("MSyncGetBans", function( len, ply )
-			
-			local plygroup = ply:GetUserGroup()
-			MSync.GetBans()
-			if(ULib.ucl.query(ply,"xgui_msync"))then
-				net.Start("MSyncRevertBans")
-					net.WriteTable( MSync.Bans )
-				net.Send(ply)
-			else
-				MSync.SendMessageToAdmins(Color(255,255,255),"WARNING: Player: "..ply:GetName().." tried to exploit the server and got kicked! (A2)")
-				ply:Kick( "[MSync] CSLua: Tried to force get server settings table (A2)" )
-			end
-			
+	MSync.GetBans()
+	if(ULib.ucl.query(ply, "xgui_msync")) then
+		net.Start("MSyncRevertBans")
+			net.WriteTable(MSync.Bans)
+		net.Send(ply)
+	else
+		MSync.SendMessageToAdmins(Color(255,255,255), "WARNING: Player: " .. ply:GetName() .. " tried to exploit the server and got kicked! (A2)")
+		ply:Kick("[MSync] CSLua: Tried to force get server settings table (A2)")
+	end
 end)
-//Get Table and save the Settings
+-- Get Table and save the Settings
 net.Receive("MSyncTableSend", function( len, ply )
-
-		local plygroup = ply:GetUserGroup()
-		if(ULib.ucl.query(ply,"xgui_msync"))then
-			MSync.Settings = net.ReadTable()
-			MSync.SaveSettings()
-		else
-			MSync.SendMessageToAdmins(Color(255,255,255),"WARNING: Player: "..ply:GetName().." tried to exploit the server and got kicked! (A2)")
-			ply:Kick( "[MSync] CSLua: Tried to force-send settings table (A2)" )
-		end
+	if(ULib.ucl.query(ply,"xgui_msync")) then
+		MSync.Settings = net.ReadTable()
+		MSync.SaveSettings()
+	else
+		MSync.SendMessageToAdmins(Color(255,255,255), "WARNING: Player: " .. ply:GetName() .. " tried to exploit the server and got kicked! (A2)")
+		ply:Kick("[MSync] CSLua: Tried to force-send settings table (A2)")
+	end
 end)
 
 function MSync.SendMessageToAdmins(col,text)
@@ -137,18 +130,93 @@ function MSync.SendMessageToAdmins(col,text)
 	end
 end
 
-function MSync.PrintToAll(col,text)
+function MSync.PrintToAll(col, text)
+	print(text)
 	net.Start("MSyncChatPrint")
 		net.WriteColor(col)
 		net.WriteString(text)
 	net.Broadcast()
 end
 
-function MSync.Print(ply,col,text)
+function MSync.Print(ply, col, text)
+	if ply.IsValid == nil or not ply:IsValid() then
+		print(text)
+	end
 	net.Start("MSyncChatPrint")
 		net.WriteColor(col)
 		net.WriteString(text)
 	net.Send(ply)
+end
+
+-- Builds and returns ban message for displaying to the player
+function MSync.GetBannedMessage(reason, ban_timestamp, duration_seconds, staffName)
+	return
+	"You are banned!\n" ..
+	"------------------------\n" ..
+	"Reason: " .. reason .. "\n" ..
+	"Banned by: " .. staffName .. "\n" ..
+	"Duration: " .. MSync.FormatTime(duration_seconds) .. "\n" ..
+	"Lifted in: " .. MSync.FormatTime((ban_timestamp + duration_seconds) - os.time()) .. "\n" ..
+	"------------------------\n" ..
+	"You may appeal your ban at http://unitedponyrepublic.eu"
+end
+
+-- Converts seconds to human-readable string
+-- Example: 2 years 8 months 16 days 3 hours 43 minutes 12 seconds
+function MSync.FormatTime(seconds)
+
+	if tonumber(seconds) <= 0 then
+		return "Permanent";
+	else
+		local secondsInYear = 31556926
+		local secondsInMonth = 2629744
+		local secondsInDay = 86400
+		local secondsInHour = 3600
+		local secondsInMinute = 60
+		local result = ""
+		local remainder = tonumber(seconds)
+		if remainder >= secondsInYear then
+			years = math.floor(remainder/secondsInYear)
+			result = result .. string.format("%d years ", years);
+			remainder = remainder - years * secondsInYear
+		end
+		if remainder >= secondsInMonth then
+			months = math.floor(remainder/secondsInMonth)
+			result = result .. string.format("%d months ", months);
+			remainder = remainder - months * secondsInMonth
+		end
+		if remainder >= secondsInDay then
+			days = math.floor(remainder/secondsInDay)
+			result = result .. string.format("%d days ", days);
+			remainder = remainder - days * secondsInDay
+		end
+		if remainder >= secondsInHour then
+			hours = math.floor(remainder/secondsInHour)
+			result = result .. string.format("%d hours ", hours);
+			remainder = remainder - hours * secondsInHour
+		end
+		if remainder >= secondsInMinute then
+			minutes = math.floor(remainder/secondsInMinute)
+			result = result .. string.format("%d minutes ", minutes);
+			remainder = remainder - minutes * secondsInMinute
+		end
+		if remainder > 0 then
+			result = result .. string.format("%d seconds", remainder);
+		end
+
+		return result
+	end
+end
+
+-- Converts seconds to human-readable date and time
+-- TODO find if this has any usages
+function MSync.FormatDateTime(timestamp)
+	return os.date("%d/%m/%Y %H:%M", timestamp)
+end
+
+-- Returns whether or not ply is a valid player
+function MSync.IsValidPlayer(ply)
+	return ply.IsValid ~= nil and ply:IsValid()
 end
 
 hook.Add( "Initialize", "MSync_Load", MSync.load )

--- a/lua/msync/mbsync_chat.lua
+++ b/lua/msync/mbsync_chat.lua
@@ -17,8 +17,7 @@ if(table.HasValue(MSync.Settings.EnabledModules,"MBSync"))then
 					break
 				end
 			end
-
-			MSync.AddBanID(steamid,reason,calling_ply,minutes)
+			MSync.AddBan(steamid, "(Unknown)", nil, "(Unknown)", reason, minutes)
 			
 		end
 
@@ -34,8 +33,11 @@ if(table.HasValue(MSync.Settings.EnabledModules,"MBSync"))then
 				ULib.tsayError( calling_ply, "You cannot ban a bot.", true )
 				return
 			end
-			
-			MSync.AddBan(target_ply,reason,calling_ply,minutes)
+			if MSync:IsValidPlayer(calling_ply) then
+				MSync.AddBan(target_ply:SteamID(), target_ply:GetName(), calling_ply:SteamID(), calling_ply:GetName(), reason, minutes)
+			else
+				MSync.AddBan(target_ply:SteamID(), target_ply:GetName(), "(Unknown)", "(Console)", reason, minutes)
+			end
 		end
 
 		local MBSyncban = ulx.command( CATEGORY_NAME, "ulx ban", MSync.ban, "!ban" )

--- a/lua/msync/mbsync_chat.lua
+++ b/lua/msync/mbsync_chat.lua
@@ -5,7 +5,7 @@ if(table.HasValue(MSync.Settings.EnabledModules,"MBSync"))then
 		function MSync.banid( calling_ply, steamid, minutes, reason )
 			steamid = steamid:upper()
 			if not ULib.isValidSteamID( steamid ) then
-				ULib.tsayError( calling_ply, "Invalid steamid." )
+				ULib.tsayError( calling_ply, "Invalid SteamID." )
 				return
 			end
 
@@ -23,18 +23,17 @@ if(table.HasValue(MSync.Settings.EnabledModules,"MBSync"))then
 		end
 
 		local MBSyncbanid = ulx.command( CATEGORY_NAME, "ulx banid", MSync.banid, "!banid" )
-		MBSyncbanid:addParam{ type=ULib.cmds.StringArg, hint="steamid" }
+		MBSyncbanid:addParam{ type=ULib.cmds.StringArg, hint="SteamID" }
 		MBSyncbanid:addParam{ type=ULib.cmds.NumArg, hint="minutes, 0 for perma", ULib.cmds.optional, ULib.cmds.allowTimeString, min=0 }
 		MBSyncbanid:addParam{ type=ULib.cmds.StringArg, hint="reason", ULib.cmds.optional, ULib.cmds.takeRestOfLine, completes=ulx.common_kick_reasons }
 		MBSyncbanid:defaultAccess( ULib.ACCESS_SUPERADMIN )
-		MBSyncbanid:help( "[MBSync] Bans steamid." )
+		MBSyncbanid:help( "[MBSync] Bans SteamID." )
 
 		function MSync.ban( calling_ply, target_ply, minutes, reason )
 			if target_ply:IsBot() then
-				ULib.tsayError( calling_ply, "Cannot ban a bot", true )
+				ULib.tsayError( calling_ply, "You cannot ban a bot.", true )
 				return
 			end
-
 			
 			MSync.AddBan(target_ply,reason,calling_ply,minutes)
 		end
@@ -50,38 +49,38 @@ if(table.HasValue(MSync.Settings.EnabledModules,"MBSync"))then
 		function MSync.unban( calling_ply, steamid )
 			steamid = steamid:upper()
 			if not ULib.isValidSteamID( steamid ) then
-				ULib.tsayError( calling_ply, "Invalid steamid." )
+				ULib.tsayError( calling_ply, "Invalid SteamID." )
 				return
 			end
 
 			MSync.RemoveBan(steamid,calling_ply)
 		end
 		local MBSyncunban = ulx.command( CATEGORY_NAME, "ulx unban", MSync.unban,"!unban" )
-		MBSyncunban:addParam{ type=ULib.cmds.StringArg, hint="steamid" }
+		MBSyncunban:addParam{ type=ULib.cmds.StringArg, hint="SteamID" }
 		MBSyncunban:defaultAccess( ULib.ACCESS_ADMIN )
-		MBSyncunban:help( "[MBSync] Unbans steamid." )
+		MBSyncunban:help( "[MBSync] Unbans SteamID." )
 		
 		function MSync.CheckPlayerBan(calling_ply, steamid)
 		
 			steamid = steamid:upper()
 			if not ULib.isValidSteamID( steamid ) then
-				ULib.tsayError( calling_ply, "Invalid steamid." )
+				ULib.tsayError( calling_ply, "Invalid SteamID." )
 				return
 			end
 			
 			MSync.CheckBan(steamid,calling_ply)
 		end
 		local MBSyncbancheck = ulx.command(CATEGORY_NAME, "ulx checkban", MSync.CheckPlayerBan, "!checkban" )
-		MBSyncbancheck:addParam{ type=ULib.cmds.StringArg, hint="steamid" }
+		MBSyncbancheck:addParam{ type=ULib.cmds.StringArg, hint="SteamID" }
 		MBSyncbancheck:defaultAccess( ULib.ACCESS_ADMIN )
-		MBSyncbancheck:help( "[MBSync] Check if target is Banned." )
+		MBSyncbancheck:help( "[MBSync] Check if target is banned." )
 		
 		print("[MBSync] Overwritten ULX Commands")
 	end
 
 	function MSync.CheckULX()
 		if not ulx.banid or not ulx.ban then
-			print("[MBSync] ULX not Loaded! Rechecking in 5 Seconds!")
+			print("[MBSync] ULX not loaded! Rechecking in 5 seconds!")
 			timer.Simple(5,function() MSync.CheckULX() end)
 		else
 			MSync.CommandOverwrite()

--- a/lua/msync/mbsync_sql.lua
+++ b/lua/msync/mbsync_sql.lua
@@ -5,18 +5,24 @@ if(table.HasValue(MSync.Settings.EnabledModules,"MBSync"))then
 		local BanningAdmin = admin:GetName()
 		local QbanAdd = MSync.DB:query("INSERT INTO `mbsync` (`steamid`, `admin`,`nickname`, `reason`,`ban_date`,`duration`) VALUES ('"..ply:SteamID().."', '"..MSync.DB:escape(admin:GetName()).."', '"..MSync.DB:escape(ply:GetName()).."' ,'"..MSync.DB:escape(reason).."',"..os.time()..","..(tonumber(duration)*60)..") ON DUPLICATE KEY UPDATE `admin`=VALUES(admin), `reason`=VALUES(reason),`ban_date`=VALUES(ban_date),`duration`=VALUES(duration)" )
 		QbanAdd.onSuccess = function(q)
-			MSync.PrintToAll(Color(200,0,0),"Player: "..BanPlayer.." got banned for reason: "..reason.." by: "..BanningAdmin.." for: "..duration.." Minutes")
+			MSync.PrintToAll(Color(200,0,0),"Player: "..BanPlayer.." got banned for reason: "..reason.." by: "..BanningAdmin.." for: "..duration.." minutes")
 		end
 		QbanAdd.onError = function(Q,E) print("Q1") print(E) end
 		QbanAdd:start()
 		QbanAdd:wait()
-		ply:Kick("[MBSync] You are Banned! \nReason: "..reason.."\nDuration: "..duration.." \nBanned by: "..BanningAdmin.." \nUnban Date: "..os.date( "%H:%M - %d/%m/%Y" ,(duration + os.time())))
+		ply:Kick(
+			"[MBSync] You are banned!\n" ..
+			"Reason: " .. reason .. "\n" ..
+			"Duration: " .. duration .. "\n" ..
+			"Banned by: " .. BanningAdmin .. "\n" ..
+			"Unban date: " .. os.date("%H:%M - %d/%m/%Y" , duration + os.time())
+		)
 	end
 	
 	function MSync.AddBanID(ply,reason,admin,duration)
 		local QbanIDAdd = MSync.DB:query("INSERT INTO `mbsync` (`steamid`, `admin`,`nickname`, `reason`,`ban_date`,`duration`) VALUES ('"..ply.."', '"..MSync.DB:escape(admin:GetName()).."', 'null' ,'"..MSync.DB:escape(reason).."',"..os.time()..","..(tonumber(duration)*60)..") ON DUPLICATE KEY UPDATE `admin`=VALUES(admin), `reason`=VALUES(reason),`ban_date`=VALUES(ban_date),`duration`=VALUES(duration)")
 		QbanIDAdd.onSuccess = function(q)
-			MSync.PrintToAll(Color(200,0,0),"Player: "..ply.." got banned for Reason: "..reason.." by: "..admin:GetName().." for: "..duration.." Minutes")
+			MSync.PrintToAll(Color(200,0,0),"Player: "..ply.." got banned for reason: "..reason.." by: "..admin:GetName().." for: "..duration.." minutes")
 		end
 		QbanIDAdd.onError = function(Q,E) print("Q1") print(E) end
 		--game.KickID(ply,"You got banned for "..reason.." by "..admin:GetName().." for "..duration.." Minutes")
@@ -26,7 +32,7 @@ if(table.HasValue(MSync.Settings.EnabledModules,"MBSync"))then
 	function MSync.RemoveBan(ply,admin)
 		local QremBan = MSync.DB:query("DELETE FROM `mbsync` WHERE `steamid` = '" .. ply .. "'")
 		QremBan.onSuccess = function(q)
-			MSync.PrintToAll(Color(33,255,0),"Player: "..ply.." got unbanned from: "..admin:GetName())
+			MSync.PrintToAll(Color(33,255,0),"Player: "..ply.." got unbanned by: "..admin:GetName())
 		end
 		QremBan:start()
 	end
@@ -34,8 +40,6 @@ if(table.HasValue(MSync.Settings.EnabledModules,"MBSync"))then
 	
 	function MSync.CheckBan(ply,admin)
 		local QcheckBan = MSync.DB:query("SELECT * FROM `mbsync` WHERE steamid = '" .. ply .. "'")
-	
-		
 		
 		QcheckBan.onError = function(Q,E) print("Q1") print(E) end
 		
@@ -44,29 +48,22 @@ if(table.HasValue(MSync.Settings.EnabledModules,"MBSync"))then
 		
 		if QcheckBan:getData()[1] then
 			banTable = QcheckBan:getData()
-			
 		end
 		
 		if QcheckBan:getData()[1] then
-			
 
 			if (banTable[1].duration<=0)then
-				
-				MSync.Print(admin,Color(160,160,0),"Player "..ply.." got banned for "..banTable.Reason.." by "..banTable.Admin.." for Permanent")
-
-			
+				MSync.Print(admin,Color(160,160,0),"Player "..ply.." got banned for reason "..banTable.Reason.." by "..banTable.Admin.." permanently")
 			elseif(banTable[1].duration + banTable[1].ban_date>=os.time())then
-				MSync.Print(admin,Color(160,160,0),("Player "..ply.." got banned for "..banTable.reason.." by "..banTable.admin.." untill "..os.date( "%H:%M - %d/%m/%Y" ,(banTable[1].duration + banTable[1].ban_date))))
+				MSync.Print(admin,Color(160,160,0),("Player "..ply.." got banned for reason "..banTable.reason.." by "..banTable.admin.." until "..os.date( "%H:%M - %d/%m/%Y" ,(banTable[1].duration + banTable[1].ban_date))))
 			else
 				MSync.Print(admin,Color(160,160,0),("Player "..ply.." got unbanned: Ban expired"))
 				MSync.RemoveBan(ply,admin)
 			end
 		else
-			MSync.Print(admin,Color(160,160,0),("Player "..ply.." is not Banned!"))
+			MSync.Print(admin,Color(160,160,0),("Player "..ply.." is not banned."))
 			
 		end
-		
-		
 		
 	end
 	
@@ -77,13 +74,11 @@ if(table.HasValue(MSync.Settings.EnabledModules,"MBSync"))then
 		MSync.Bans = QgetBans:getData()
 	end
 	
-
 	function MSync.CheckIfBanned(ply)
 		local QcheckIfBan = MSync.DB:query("SELECT * FROM `mbsync` WHERE steamid = '" .. ply .. "'")
 		local banTable = nil
-		print("[MBSync] Checking if "..ply.." is Banned...")
+		print("[MBSync] Checking if "..ply.." is banned...")
 		
-
 		QcheckIfBan.onError = function(Q,E) print("Q1") print(E) end
 		
 		QcheckIfBan:start()
@@ -91,29 +86,27 @@ if(table.HasValue(MSync.Settings.EnabledModules,"MBSync"))then
 
 		if QcheckIfBan:getData()[1] then
 			banTable = QcheckIfBan:getData()
-			
 		end
 		
 		if QcheckIfBan:getData()[1] then
-			
 
 			if (banTable[1].duration<=0)then
 				
-				print("[MBSync] Player "..ply.." is Banned!")
+				print("[MBSync] Player "..ply.." is banned.")
 				banTable[1].bool = false
 				return banTable[1]
 			
 			elseif(banTable[1].duration + banTable[1].ban_date>=os.time())then
-				print("[MBSync] Player "..ply.." is Banned!")
+				print("[MBSync] Player "..ply.." is banned.")
 				banTable[1].bool = false
 				return banTable[1]
 			else
-				print("[MBSync] Player "..ply.." is not Banned!")
+				print("[MBSync] Player "..ply.." is not banned.")
 				return true
 				
 			end
 		else
-			print("[MBSync] Player "..ply.." is not Banned!")
+			print("[MBSync] Player "..ply.." is not banned.")
 			return true
 			
 		end

--- a/lua/msync/mbsync_sql.lua
+++ b/lua/msync/mbsync_sql.lua
@@ -10,7 +10,7 @@ if(table.HasValue(MSync.Settings.EnabledModules,"MBSync"))then
 		QbanAdd.onError = function(Q,E) print("Q1") print(E) end
 		QbanAdd:start()
 		QbanAdd:wait()
-		ply:Kick("[MBSync] You are Banned! \nReason: "..reason.."\nDuration: "..duration.." Minutes \nBanned by: "..BanningAdmin.." \nUnban Date: "..os.date( "%H:%M - %d/%m/%Y" ,(duration + os.time())))
+		ply:Kick("[MBSync] You are Banned! \nReason: "..reason.."\nDuration: "..duration.." \nBanned by: "..BanningAdmin.." \nUnban Date: "..os.date( "%H:%M - %d/%m/%Y" ,(duration + os.time())))
 	end
 	
 	function MSync.AddBanID(ply,reason,admin,duration)

--- a/lua/msync/mbsync_sql.lua
+++ b/lua/msync/mbsync_sql.lua
@@ -1,143 +1,166 @@
-if(table.HasValue(MSync.Settings.EnabledModules, "MBSync"))then	
+if(table.HasValue(MSync.Settings.EnabledModules, "MBSync")) then
 	print("[MBSync] Loading...")
-	-- TODO duplicate code in AddBan and AddBanID - can be wrapped
 
-	function MSync.AddBan(ply,reason,admin,duration)
-		local BanPlayer = ply:GetName()
-		local BanningAdmin = admin:GetName()
+	function MSync.AddBan(steamid, name, staff_steamid, staff_name, reason, duration_minutes)
+
+		-- Put all queries into a trasaction for atomicity
+		local transaction = MSync.DB:createTransaction()
+
+		-- First, "shorten" last permanent ban (if any) to end right now
+		local ReleasePermanentBans = MSync.DB:prepare([[
+			UPDATE `]] .. MSync.TableNameBans .. [[`
+				SET `duration` = (UNIX_TIMESTAMP() - `ban_date`)
+				WHERE `steamid` = ? AND `duration` = 0
+				ORDER BY `ban_date` DESC LIMIT 1
+		]])
+		ReleasePermanentBans:setString(1, steamid)
+		transaction:addQuery(ReleasePermanentBans)
+
+		-- Then, shorten last temporary ban which is still in effect (if any) to end right now
+		local ShortenBans = MSync.DB:prepare([[
+			UPDATE `]] .. MSync.TableNameBans .. [[`
+				SET `duration` = (UNIX_TIMESTAMP() - `ban_date`)
+				WHERE `steamid` = ? AND (`ban_date` + `duration` > UNIX_TIMESTAMP())
+				ORDER BY `ban_date` DESC LIMIT 1
+		]])
+		ShortenBans:setString(1, steamid)
+		transaction:addQuery(ShortenBans)
+
+		-- Then finally add the new ban
 		local QbanAdd = MSync.DB:prepare([[
-			INSERT INTO `]] .. MSync.TableNameBans .. [[` (`steamid`, `admin`, `nickname`, `reason`, `ban_date`, `duration`)
-			VALUES (?, ?, ?, ?, ?, ?) ON DUPLICATE KEY UPDATE `admin`=VALUES(admin), `reason`=VALUES(reason), `ban_date`=VALUES(ban_date), `duration`=VALUES(duration)
+			INSERT INTO `]] .. MSync.TableNameBans .. [[`
+				(`steamid`, `name`, `staff_steamid`, `staff_name`, `reason`, `ban_date`, `duration`)
+				VALUES (?, ?, ?, ?, ?, ?, ?)
 		]])
-		QbanAdd:setString(1, ply:SteamID())
-		QbanAdd:setString(2, admin:GetName())
-		QbanAdd:setString(3, ply:GetName())
-		QbanAdd:setString(4, reason)
-		QbanAdd:setNumber(5, os.time())
-		QbanAdd:setNumber(6, tonumber(duration) * 60)
-		QbanAdd.onSuccess = function(q)
-			MSync.PrintToAll(Color(200,0,0), "Player: " .. BanPlayer .. " got banned for reason: " .. reason .. " by: " .. BanningAdmin .. " for: " .. duration .. " minutes")
+		QbanAdd:setString(1, steamid)
+		QbanAdd:setString(2, name)
+		if staff_steamid == nil then
+			QbanAdd:setNull(3)
+		else
+			QbanAdd:setString(3, staff_steamid)
 		end
-		QbanAdd.onError = function(Q,E) print("Q1") print(E) end
-		QbanAdd:start()
-		-- TODO is there a good reason to wait here?
-		QbanAdd:wait()
-		ply:Kick(
-			"[MBSync] You are banned!\n" ..
-			"Reason: " .. reason .. "\n" ..
-			"Duration: " .. duration .. "\n" ..
-			"Banned by: " .. BanningAdmin .. "\n" ..
-			"Unban date: " .. os.date("%H:%M - %d/%m/%Y" , duration + os.time())
-		)
+		QbanAdd:setString(4, staff_name)
+		QbanAdd:setString(5, reason)
+		QbanAdd:setNumber(6, os.time())
+		QbanAdd:setNumber(7, tonumber(duration_minutes) * 60)
+		transaction:addQuery(QbanAdd)
+
+		transaction.onSuccess = function()
+			game.KickID(steamid, MSync.GetBannedMessage(reason, os.time(), duration_minutes * 60, staff_name))
+			if duration_minutes <= 0 then
+				MSync.PrintToAll(Color(200,0,0), "Player " .. name .. " got permanently banned for reason: " .. reason .. " by: " .. staff_name)
+			else
+				MSync.PrintToAll(Color(200,0,0), "Player " .. name .. " got banned for " .. MSync.FormatTime(duration_minutes * 60) .. " for reason: " .. reason .. " by: " .. staff_name)
+			end
+		end
+		transaction.onError = function(Q, E) print("[MBSync] Error while banning: " .. E) end
+		transaction:start()
 	end
-	
-	function MSync.AddBanID(ply,reason,admin,duration)
-		local QbanIDAdd = MSync.DB:prepare([[
-			INSERT INTO `]] .. MSync.TableNameBans .. [[` (`steamid`, `admin`,`nickname`, `reason`, `ban_date`, `duration`) VALUES (?, ?, ?, ?, ?, ?)
-			ON DUPLICATE KEY UPDATE `admin`=VALUES(admin), `reason`=VALUES(reason),`ban_date`=VALUES(ban_date),`duration`=VALUES(duration)
+
+	function MSync.RemoveBan(steamid, staff)
+		local staffName = MSync:IsValidPlayer(staff) and staff:GetName() or "(Console)"
+		local QremBan = MSync.DB:prepare([[
+			UPDATE `]] .. MSync.TableNameBans .. [[`
+			SET `duration` = (UNIX_TIMESTAMP() - `ban_date`)
+			WHERE `steamid` = ? AND
+			(`ban_date` + `duration` > UNIX_TIMESTAMP() OR `duration` = 0)
+			ORDER BY `ban_date` DESC LIMIT 1
 		]])
-		QbanIDAdd:setString(1, ply)
-		QbanIDAdd:setString(2, admin:GetName())
-		QbanIDAdd:setString(3, "NULL")
-		QbanIDAdd:setString(4, reason)
-		QbanIDAdd:setNumber(5, os.time())
-		QbanIDAdd:setNumber(6, tonumber(duration) * 60)
-		QbanIDAdd.onSuccess = function(q)
-			MSync.PrintToAll(Color(200,0,0), "Player: " .. ply .. " got banned for reason: " .. reason .. " by: " .. admin:GetName() .. " for: " .. duration .. " minutes")
-		end
-		QbanIDAdd.onError = function(Q,E) print("Q1") print(E) end
-		--game.KickID(ply,"You got banned for "..reason.." by "..admin:GetName().." for "..duration.." Minutes")
-		QbanIDAdd:start()
-	end
-	
-	function MSync.RemoveBan(ply,admin)
-		local QremBan = MSync.DB:prepare("DELETE FROM `" .. MSync.TableNameBans .. "` WHERE `steamid` = ?")
-		QremBan:setString(1, ply)
+		QremBan:setString(1, steamid)
 		QremBan.onSuccess = function(q)
-			MSync.PrintToAll(Color(33,255,0), "Player: " .. ply .. " got unbanned by: " .. admin:GetName())
+			if (q:affectedRows() > 0) then
+				MSync.PrintToAll(Color(33,255,0), "Player " .. steamid .. " got unbanned by: " .. staffName)
+			else
+				MSync.Print(staff, Color(160,160,0), ("Cannot unban " .. steamid .. " - not banned."))
+			end
 		end
 		QremBan:start()
 	end
-		
-	
-	function MSync.CheckBan(ply,admin)
-		local QcheckBan = MSync.DB:prepare("SELECT * FROM `" .. MSync.TableNameBans .. "` WHERE steamid = ?")
-		QcheckBan:setString(1, ply)
-		
-		QcheckBan.onError = function(Q,E) print("Q1") print(E) end
-		
-		QcheckBan:start()
-		-- TODO why not use onSuccess here instead of waiting?
-		QcheckBan:wait()
-		
-		if QcheckBan:getData()[1] then
-			banTable = QcheckBan:getData()
-		end
-		
-		if QcheckBan:getData()[1] then
 
-			if (banTable[1].duration <= 0)then
-				MSync.Print(admin, Color(160,160,0), "Player " .. ply .. " got banned for reason " .. banTable.Reason .. " by " .. banTable.Admin .. " permanently")
-			elseif(banTable[1].duration + banTable[1].ban_date >= os.time()) then
-				MSync.Print(admin, Color(160,160,0), ("Player " .. ply .. " got banned for reason " .. banTable.reason .. " by " .. banTable.admin .. " until " .. os.date( "%H:%M - %d/%m/%Y" , (banTable[1].duration + banTable[1].ban_date))))
+	function MSync.CheckBan(steamid, staff)
+		local QcheckBan = MSync.DB:prepare("SELECT * FROM `" .. MSync.TableNameBans .. "` WHERE `steamid` = ? AND (`ban_date` + `duration` > UNIX_TIMESTAMP() OR `duration` = 0) ORDER BY `ban_date` DESC LIMIT 1")
+		QcheckBan:setString(1, steamid)
+
+		QcheckBan.onError = function(Q,E) print("Q1") print(E) end
+		QcheckBan.onSuccess = function (q, data)
+
+			if data[1] ~= nil then
+
+				banTable = data[1]
+				if (banTable.duration <= 0) then
+					MSync.Print(staff, Color(160,160,0), "Player " .. steamid .. " got banned for reason " .. banTable.reason .. " by " .. banTable.staff_name .. " permanently")
+				elseif(banTable.duration + banTable.ban_date >= os.time()) then
+					MSync.Print(staff, Color(160,160,0), ("Player " .. steamid .. " got banned for reason " .. banTable.reason .. " by " .. banTable.staff_name .. " until " .. MSync.FormatDateTime(banTable.duration + banTable.ban_date)))
+				end
 			else
-				MSync.Print(admin, Color(160,160,0), ("Player " .. ply .. " got unbanned: Ban expired"))
-				MSync.RemoveBan(ply, admin)
+				MSync.Print(staff, Color(160,160,0), ("Player " .. steamid .. " is not banned."))
 			end
-		else
-			MSync.Print(admin, Color(160,160,0), ("Player " .. ply .. " is not banned."))
-			
 		end
-		
+		QcheckBan:start()
 	end
-	
+
 	function MSync.GetBans()
-		local QgetBans = MSync.DB:prepare("SELECT * FROM `" .. MSync.TableNameBans .. "`")
-		QgetBans:start()
-		-- TODO why not use onSuccess instead of waiting?
-		QgetBans:wait()
-		MSync.Bans = QgetBans:getData()
+		local q = MSync.DB:prepare("SELECT * FROM `" .. MSync.TableNameBans .. "`")
+		q.onSuccess = function(q, data)
+			MSync.Bans = data
+		end
+		q:start()
+		-- TODO refactor this so we don't have to wait here
+		q:wait()
 	end
-	
-	function MSync.CheckIfBanned(ply)
-		local QcheckIfBan = MSync.DB:prepare("SELECT * FROM `" .. MSync.TableNameBans .. "` WHERE steamid = ?")
+
+	-- Asynchronous version of CheckIfBanned. Calls the callback after finishing,
+	-- passing the ban data if the player is banned and false if they aren't.
+	function MSync.CheckIfBanned(ply, callback)
+		local QcheckIfBan = MSync.DB:prepare([[
+			SELECT * FROM `]] .. MSync.TableNameBans .. [[`
+			WHERE `steamid` = ? AND
+			(`ban_date` + `duration` > UNIX_TIMESTAMP() OR `duration` = 0)
+			ORDER BY `ban_date` DESC LIMIT 1]]
+		)
 		QcheckIfBan:setString(1, ply)
 
 		local banTable = nil
 		print("[MBSync] Checking if " .. ply .. " is banned...")
-		
-		QcheckIfBan.onError = function(Q,E) print("Q1") print(E) end
-		
-		QcheckIfBan:start()
-		-- TODO why not use onSuccess instead of waiting?
-		QcheckIfBan:wait()
 
-		if QcheckIfBan:getData()[1] then
-			banTable = QcheckIfBan:getData()
-		end
-		
-		if QcheckIfBan:getData()[1] then
-
-			if (banTable[1].duration <= 0)then
-				
+		QcheckIfBan.onError = function(q, err) print("Q1: " .. err) end
+		-- Call the callback with the ban data on success, false if no active ban found
+		QcheckIfBan.onSuccess = function(q, data)
+			if data ~= nil and data[1] ~= nil then
 				print("[MBSync] Player " .. ply .. " is banned.")
-				banTable[1].bool = false
-				return banTable[1]
-			
-			elseif(banTable[1].duration + banTable[1].ban_date >= os.time())then
-				print("[MBSync] Player " .. ply .. " is banned.")
-				banTable[1].bool = false
-				return banTable[1]
+				callback(data[1])
 			else
 				print("[MBSync] Player " .. ply .. " is not banned.")
-				return true
+				callback(false)
 			end
-		else
-			print("[MBSync] Player " .. ply .. " is not banned.")
-			return true
 		end
-		
+		QcheckIfBan:start()
 	end
-	
+
+	-- Synchronous version, only used when we absolutely need the result before continuing
+	-- This waits until the query finishes, so it freezes the server in the meantime
+	function MSync.CheckIfBannedSync(ply)
+		local QcheckIfBan = MSync.DB:prepare([[
+			SELECT * FROM `]] .. MSync.TableNameBans .. [[`
+			WHERE `steamid` = ? AND
+			(`ban_date` + `duration` > UNIX_TIMESTAMP() OR `duration` = 0)
+			ORDER BY `ban_date` DESC LIMIT 1]]
+		)
+		QcheckIfBan:setString(1, ply)
+
+		local banTable = nil
+		print("[MBSync] Checking if " .. ply .. " is banned...")
+
+		QcheckIfBan.onError = function(q, err) print("Q1: " .. err) end
+
+		QcheckIfBan:start()
+		QcheckIfBan:wait()
+
+		if QcheckIfBan:getData() ~= nil and QcheckIfBan:getData()[1] ~= nil then
+			print("[MBSync] Player " .. ply .. " is banned.")
+			return QcheckIfBan:getData()[1]
+		end
+		return false
+	end
 	print("[MBSync] Loading completed!")
 end

--- a/lua/msync/mrsync_sql.lua
+++ b/lua/msync/mrsync_sql.lua
@@ -2,7 +2,7 @@ if(table.HasValue(MSync.Settings.EnabledModules,"MRSync"))then
 	print("[MRSync] Loading...")
 	//Function to load a Players Rank
 	function MSync.LoadRank(ply)
-		print("[MRSync] Loading Player Rank...")
+		print("[MRSync] Loading player rank...")
 			local queryQ = MSync.DB:query("SELECT * FROM `mrsync` WHERE steamid = '" .. ply:SteamID() .. "' AND (`servergroup` = '" .. MSync.Settings.Servergroup .. "' OR `servergroup` = 'allserver')")
 			queryQ.onData = function(Q,D)
 					queryQ.onSuccess = function(q)
@@ -11,19 +11,19 @@ if(table.HasValue(MSync.Settings.EnabledModules,"MRSync"))then
 							
 							if( ply:IsUserGroup(D.groups))then
 							
-								print("[MRSync] User "..ply:GetName().." is already in his Group!")
+								print("[MRSync] User "..ply:GetName().." is already in their group!")
 								
 							elseif(D.groups=="user")then
 							
 								RunConsoleCommand( 'ulx', 'removeuserid', ply:SteamID() )
-								print("[MRSync] Adding "..ply:GetName().." to Group "..D.groups)
-								MSync.PrintToAll(Color(255,255,255),"Adding "..ply:GetName().."to Group "..D.groups)
+								print("[MRSync] Adding "..ply:GetName().." to group "..D.groups)
+								MSync.PrintToAll(Color(255,255,255),"Adding "..ply:GetName().." to group "..D.groups)
 								
 							else
 							
-								print("[MRSync] Adding "..ply:GetName().." to Group "..D.groups)
+								print("[MRSync] Adding "..ply:GetName().." to group "..D.groups)
 								RunConsoleCommand( 'ulx', 'adduserid', ply:SteamID(),D.groups )
-								MSync.PrintToAll(Color(255,255,255),"Adding "..ply:GetName().."to Group "..D.groups)
+								MSync.PrintToAll(Color(255,255,255),"Adding "..ply:GetName().." to group "..D.groups)
 								
 							end
 						end
@@ -35,7 +35,7 @@ if(table.HasValue(MSync.Settings.EnabledModules,"MRSync"))then
 	end
 	// Function to save a Single user 
 	function MSync.SaveRank(ply)
-		print("[MRSync] Saving Player Rank...")
+		print("[MRSync] Saving player rank...")
 		local plyTable = {
 			steamid = ply:SteamID(),
 			rank = ply:GetUserGroup(),
@@ -45,7 +45,7 @@ if(table.HasValue(MSync.Settings.EnabledModules,"MRSync"))then
 		local deleteQ = MSync.DB:query("DELETE FROM `mrsync` WHERE `steamid` = '" .. plyTable.steamid .. "' AND (`servergroup` = '" .. MSync.Settings.Servergroup .. "' OR `servergroup` = 'allserver')")
 		deleteQ.onSuccess = function(q)
 			if checkQuery(q) then
-					print ("[MRSync] User "..plyTable.name.." is already created")
+				print ("[MRSync] User "..plyTable.name.." already exists")
 			end
 		end
 		deleteQ:start()
@@ -56,28 +56,28 @@ if(table.HasValue(MSync.Settings.EnabledModules,"MRSync"))then
 			local InsertQ = MSync.DB:query("INSERT INTO `mrsync` (`steamid`, `groups`, `servergroup`) VALUES ('"..plyTable.steamid.."', '"..plyTable.rank.."','"..MSync.Settings.Servergroup.."')")
 			InsertQ.onError = function(Q,E) print("Q1") print(E) end
 			InsertQ:start()
-			print ("[MRSync] User "..plyTable.name.." got Saved")
+			print ("[MRSync] User "..plyTable.name.." got saved")
 			
 		elseif(table.HasValue(MSync.Settings.mrsync.AllServerRanks,plyTable.rank)) and not(table.HasValue(MSync.Settings.mrsync.IgnoredRanks,plyTable.rank)) then
 		
 			local InsertQ = MSync.DB:query("INSERT INTO `mrsync` (`steamid`, `groups`, `servergroup`) VALUES ('"..plyTable.steamid.."', '"..plyTable.rank.."','allserver')")
 			InsertQ.onError = function(Q,E) print("Q1") print(E) end
 			InsertQ:start()
-			print ("[MRSync] User "..plyTable.name.." SID: "..ply:SteamID().." got Saved [A]")
+			print ("[MRSync] User "..plyTable.name.." SID: "..ply:SteamID().." got saved [A]")
 			
 		end
 
 	end
 	//Function to save all users
 	function MSync.SaveAllRanks()
-		print("[MRSync] Saving Player Ranks...")
+		print("[MRSync] Saving player ranks...")
 		local plyTable = player.GetAll()
 		for k,v in pairs(plyTable) do
 
 			local deleteQ = MSync.DB:query("DELETE FROM `mrsync` WHERE `steam` = '" .. v:SteamID() .. "' AND `servergroup` = '" .. MSync.Settings.Servergroup .. "' OR `servergroup` = 'allserver'")
 			deleteQ.onSuccess = function(q)
 				if checkQuery(q) then
-					print("[MRSync] Saving Users...")
+					print("[MRSync] Saving users...")
 				end
 			end
 			deleteQ:start()

--- a/lua/msync/mrsync_sql.lua
+++ b/lua/msync/mrsync_sql.lua
@@ -1,7 +1,7 @@
-if(table.HasValue(MSync.Settings.EnabledModules, "MRSync")) then	
+if(table.HasValue(MSync.Settings.EnabledModules, "MRSync")) then
 	print("[MRSync] Loading...")
 
-	//Function to load a Players Rank
+	-- Function to load a Players Rank
 	function MSync.LoadRank(ply)
 		print("[MRSync] Loading player rank...")
 		local queryQ = MSync.DB:query("SELECT * FROM `mrsync` WHERE steamid = '" .. ply:SteamID() .. "' AND (`servergroup` = '" .. MSync.Settings.Servergroup .. "' OR `servergroup` = 'allserver')")
@@ -9,23 +9,23 @@ if(table.HasValue(MSync.Settings.EnabledModules, "MRSync")) then
 			queryQ.onSuccess = function(q)
 				if checkQuery(q) then
 					print("[MRSync] "..ply:GetName().." Status: "..tostring(ply:IsUserGroup(D.groups)))
-					
+
 					if( ply:IsUserGroup(D.groups)) then
-					
+
 						print("[MRSync] User "..ply:GetName().." is already in their group!")
-						
+
 					elseif(D.groups=="user") then
-					
+
 						RunConsoleCommand( 'ulx', 'removeuserid', ply:SteamID() )
 						print("[MRSync] Adding "..ply:GetName().." to group "..D.groups)
 						MSync.PrintToAll(Color(255,255,255),"Adding "..ply:GetName().." to group "..D.groups)
-						
+
 					else
-					
+
 						print("[MRSync] Adding "..ply:GetName().." to group "..D.groups)
 						RunConsoleCommand( 'ulx', 'adduserid', ply:SteamID(),D.groups )
 						MSync.PrintToAll(Color(255,255,255),"Adding "..ply:GetName().." to group "..D.groups)
-						
+
 					end
 				end
 			end
@@ -34,7 +34,7 @@ if(table.HasValue(MSync.Settings.EnabledModules, "MRSync")) then
 		queryQ:start()
 
 	end
-	// Function to save a Single user 
+	-- Function to save a Single user
 	function MSync.SaveRank(ply)
 		print("[MRSync] Saving player rank...")
 		local plyTable = {
@@ -42,7 +42,7 @@ if(table.HasValue(MSync.Settings.EnabledModules, "MRSync")) then
 			rank = ply:GetUserGroup(),
 			name = ply:GetName()
 		}
-		
+
 		local deleteQ = MSync.DB:query("DELETE FROM `mrsync` WHERE `steamid` = '" .. plyTable.steamid .. "' AND (`servergroup` = '" .. MSync.Settings.Servergroup .. "' OR `servergroup` = 'allserver')")
 		deleteQ.onSuccess = function(q)
 			if checkQuery(q) then
@@ -51,25 +51,25 @@ if(table.HasValue(MSync.Settings.EnabledModules, "MRSync")) then
 		end
 		deleteQ:start()
 
-			   
+
 		if not(table.HasValue(MSync.Settings.mrsync.AllServerRanks,plyTable.rank)) and not(table.HasValue(MSync.Settings.mrsync.IgnoredRanks,plyTable.rank)) then
-		
+
 			local InsertQ = MSync.DB:query("INSERT INTO `mrsync` (`steamid`, `groups`, `servergroup`) VALUES ('"..plyTable.steamid.."', '"..plyTable.rank.."','"..MSync.Settings.Servergroup.."')")
 			InsertQ.onError = function(Q,E) print("Q1") print(E) end
 			InsertQ:start()
 			print ("[MRSync] User "..plyTable.name.." got saved")
-			
+
 		elseif(table.HasValue(MSync.Settings.mrsync.AllServerRanks,plyTable.rank)) and not(table.HasValue(MSync.Settings.mrsync.IgnoredRanks,plyTable.rank)) then
-		
+
 			local InsertQ = MSync.DB:query("INSERT INTO `mrsync` (`steamid`, `groups`, `servergroup`) VALUES ('"..plyTable.steamid.."', '"..plyTable.rank.."','allserver')")
 			InsertQ.onError = function(Q,E) print("Q1") print(E) end
 			InsertQ:start()
 			print ("[MRSync] User "..plyTable.name.." SID: "..ply:SteamID().." got saved [A]")
-			
+
 		end
 
 	end
-	//Function to save all users
+	-- Function to save all users
 	function MSync.SaveAllRanks()
 		print("[MRSync] Saving player ranks...")
 		local plyTable = player.GetAll()
@@ -83,23 +83,23 @@ if(table.HasValue(MSync.Settings.EnabledModules, "MRSync")) then
 			end
 			deleteQ:start()
 
-				   
+
 			if not(table.HasValue(MSync.Settings.mrsync.AllServerRanks,v:GetUserGroup())) and not(table.HasValue(MSync.Settings.mrsync.IgnoredRanks,v:GetUserGroup())) then
-			
+
 				local InsertQ = MSync.DB:query("INSERT INTO `mrsync` (`steamid`, `groups`, `servergroup`) VALUES ('"..v:SteamID().."', '"..v:GetUserGroup().."','"..MSync.Settings.Servergroup.."')")
 				InsertQ.onError = function(Q,E) print("Q1") print(E) end
 				InsertQ:start()
-				
+
 			elseif(table.HasValue(MSync.Settings.mrsync.AllServerRanks,v:GetUserGroup())) and not(table.HasValue(MSync.Settings.mrsync.IgnoredRanks,v:GetUserGroup())) then
-			
+
 				local InsertQ = MSync.DB:query("INSERT INTO `mrsync` (`steamid`, `groups`, `servergroup`) VALUES ('"..v:SteamID().."', '"..v:GetUserGroup().."','allserver')")
 				InsertQ.onError = function(Q,E) print("Q1") print(E) end
 				InsertQ:start()
-				
+
 			end
 		end
 
 	end
 	print("[MRSync] Loading completed")
-	
+
 end

--- a/lua/msync/mrsync_sql.lua
+++ b/lua/msync/mrsync_sql.lua
@@ -1,51 +1,37 @@
 if(table.HasValue(MSync.Settings.EnabledModules, "MRSync")) then	
 	print("[MRSync] Loading...")
 
-	function MSync.CreateRanksTable()
-		local MRSyncCT  = server:prepare([[
-			CREATE TABLE IF NOT EXISTS `]] .. tableName .. [[` (
-				`steamid` varchar(20) NOT NULL,
-				`groups` varchar(30) NOT NULL,
-				`servergroup` varchar(30) NOT NULL
-			)
-		]])
-		MRSyncCT.onError = function(Q, Err) print("[MRSync] Failed to create table: " .. Err) end
-		MRSyncCT:start()
-		-- TODO consider better solution than waiting here (can severly lag the server)
-		MRSyncCT:wait()
-	end
-
 	//Function to load a Players Rank
 	function MSync.LoadRank(ply)
 		print("[MRSync] Loading player rank...")
-			local queryQ = MSync.DB:query("SELECT * FROM `mrsync` WHERE steamid = '" .. ply:SteamID() .. "' AND (`servergroup` = '" .. MSync.Settings.Servergroup .. "' OR `servergroup` = 'allserver')")
-			queryQ.onData = function(Q,D)
-					queryQ.onSuccess = function(q)
-						if checkQuery(q) then
-							print("[MRSync] "..ply:GetName().." Status: "..tostring(ply:IsUserGroup(D.groups)))
-							
-							if( ply:IsUserGroup(D.groups))then
-							
-								print("[MRSync] User "..ply:GetName().." is already in their group!")
-								
-							elseif(D.groups=="user")then
-							
-								RunConsoleCommand( 'ulx', 'removeuserid', ply:SteamID() )
-								print("[MRSync] Adding "..ply:GetName().." to group "..D.groups)
-								MSync.PrintToAll(Color(255,255,255),"Adding "..ply:GetName().." to group "..D.groups)
-								
-							else
-							
-								print("[MRSync] Adding "..ply:GetName().." to group "..D.groups)
-								RunConsoleCommand( 'ulx', 'adduserid', ply:SteamID(),D.groups )
-								MSync.PrintToAll(Color(255,255,255),"Adding "..ply:GetName().." to group "..D.groups)
-								
-							end
-						end
+		local queryQ = MSync.DB:query("SELECT * FROM `mrsync` WHERE steamid = '" .. ply:SteamID() .. "' AND (`servergroup` = '" .. MSync.Settings.Servergroup .. "' OR `servergroup` = 'allserver')")
+		queryQ.onData = function(Q,D)
+			queryQ.onSuccess = function(q)
+				if checkQuery(q) then
+					print("[MRSync] "..ply:GetName().." Status: "..tostring(ply:IsUserGroup(D.groups)))
+					
+					if( ply:IsUserGroup(D.groups)) then
+					
+						print("[MRSync] User "..ply:GetName().." is already in their group!")
+						
+					elseif(D.groups=="user") then
+					
+						RunConsoleCommand( 'ulx', 'removeuserid', ply:SteamID() )
+						print("[MRSync] Adding "..ply:GetName().." to group "..D.groups)
+						MSync.PrintToAll(Color(255,255,255),"Adding "..ply:GetName().." to group "..D.groups)
+						
+					else
+					
+						print("[MRSync] Adding "..ply:GetName().." to group "..D.groups)
+						RunConsoleCommand( 'ulx', 'adduserid', ply:SteamID(),D.groups )
+						MSync.PrintToAll(Color(255,255,255),"Adding "..ply:GetName().." to group "..D.groups)
+						
 					end
+				end
 			end
-			queryQ.onError = function(Q,E) print("Q1") print(E) end
-			queryQ:start()
+		end
+		queryQ.onError = function(Q,E) print("Q1") print(E) end
+		queryQ:start()
 
 	end
 	// Function to save a Single user 

--- a/lua/msync/mrsync_sql.lua
+++ b/lua/msync/mrsync_sql.lua
@@ -1,5 +1,20 @@
-if(table.HasValue(MSync.Settings.EnabledModules,"MRSync"))then	
+if(table.HasValue(MSync.Settings.EnabledModules, "MRSync")) then	
 	print("[MRSync] Loading...")
+
+	function MSync.CreateRanksTable()
+		local MRSyncCT  = server:prepare([[
+			CREATE TABLE IF NOT EXISTS `]] .. tableName .. [[` (
+				`steamid` varchar(20) NOT NULL,
+				`groups` varchar(30) NOT NULL,
+				`servergroup` varchar(30) NOT NULL
+			)
+		]])
+		MRSyncCT.onError = function(Q, Err) print("[MRSync] Failed to create table: " .. Err) end
+		MRSyncCT:start()
+		-- TODO consider better solution than waiting here (can severly lag the server)
+		MRSyncCT:wait()
+	end
+
 	//Function to load a Players Rank
 	function MSync.LoadRank(ply)
 		print("[MRSync] Loading player rank...")

--- a/lua/msync/msync_hooks.lua
+++ b/lua/msync/msync_hooks.lua
@@ -10,7 +10,7 @@ if(table.HasValue(MSync.Settings.EnabledModules,"MBSync"))then
 		local MBSyncTbl = MSync.CheckIfBanned(util.SteamIDFrom64(steamID64))
 		local time = {}
 		if (MBSyncTbl==true) then
-			return true
+			return
 		else
 			if(MBSyncTbl.duration<=0)then
 				time.duration = "Permanent"

--- a/lua/msync/msync_hooks.lua
+++ b/lua/msync/msync_hooks.lua
@@ -8,13 +8,13 @@ if(table.HasValue(MSync.Settings.EnabledModules,"MBSync"))then
 		local MBSyncTbl = MSync.CheckIfBanned(util.SteamIDFrom64(steamID64))
 		local time = {}
 		if (MBSyncTbl==true) then
-			return nil
+			return true
 		else
 			if(MBSyncTbl.duration<=0)then
 				time.duration = "Permanent"
 				time.unban = "Never"
 			else
-				time.duration 	= (MBSyncTbl.duration/60).." Minutes "
+				time.duration 	= MBSyncTbl.duration.." Minutes "
 				time.unban		= os.date( "%H:%M - %d/%m/%Y" ,(MBSyncTbl.duration + MBSyncTbl.ban_date))
 			end
 			
@@ -32,7 +32,7 @@ if(table.HasValue(MSync.Settings.EnabledModules,"MBSync"))then
 				time.duration = "Permanent"
 				time.unban = "Never"
 			else
-				time.duration 	= (MBSyncTbl.duration/60).." Minutes "
+				time.duration 	= MBSyncTbl.duration.." Minutes "
 				time.unban		= os.date( "%H:%M - %d/%m/%Y" ,(MBSyncTbl.duration + MBSyncTbl.ban_date))
 			end
 			print("[MBSync] Backup Check: "..ply:GetName().." is Banned!")

--- a/lua/msync/msync_hooks.lua
+++ b/lua/msync/msync_hooks.lua
@@ -1,56 +1,23 @@
-if(table.HasValue(MSync.Settings.EnabledModules,"MRSync"))then
+if(table.HasValue(MSync.Settings.EnabledModules, "MRSync")) then
 	hook.Add("PlayerInitialSpawn", "MRSyncSyncUser", MSync.LoadRank)
 	hook.Add("PlayerDisconnected", "MRSyncSaveUser", MSync.SaveRank)
 	hook.Add("ShutDown", "MRSyncSaveAllUsers", MSync.SaveAllRanks)
 end
 
--- TODO lot of duplicate code
-if(table.HasValue(MSync.Settings.EnabledModules,"MBSync"))then
-	hook.Add( "CheckPassword", "MSyncBanCheck", function( steamID64 )
-		local MBSyncTbl = MSync.CheckIfBanned(util.SteamIDFrom64(steamID64))
-		local time = {}
-		if (MBSyncTbl==true) then
-			return
-		else
-			if(MBSyncTbl.duration<=0)then
-				time.duration = "Permanent"
-				time.unban = "Never"
-			else
-				time.duration 	= MBSyncTbl.duration.." minutes "
-				time.unban		= os.date( "%H:%M - %d/%m/%Y" ,(MBSyncTbl.duration + MBSyncTbl.ban_date))
-			end
-			
-			return false , (
-				"[MBSync] You are banned!\n" ..
-				"Reason: " .. MBSyncTbl.reason .. "\n" ..
-				"Duration: " .. time.duration .. "\n" ..
-				"Banned by: " .. MBSyncTbl.admin .. "\n" ..
-				"Unban date: " .. time.unban
-			)
+if(table.HasValue(MSync.Settings.EnabledModules, "MBSync")) then
+	hook.Add( "CheckPassword", "MSyncBanCheck", function(steamID64)
+		local MBSyncTbl = MSync.CheckIfBannedSync(util.SteamIDFrom64(steamID64))
+		if MBSyncTbl then
+			return false, (MSync.GetBannedMessage(MBSyncTbl.reason, MBSyncTbl.ban_date, MBSyncTbl.duration, MBSyncTbl.staff_name))
 		end
 	end)
-	
-	hook.Add( "PlayerInitialSpawn", "MSyncBanCheckBackup", function( ply )
-		local MBSyncTbl = MSync.CheckIfBanned(ply:SteamID())
-		local time = {}
-		if (MBSyncTbl==true) then
-			print("[MBSync] Backup check: "..ply:GetName().." is not banned!")
-		else
-			if(MBSyncTbl.duration<=0)then
-				time.duration = "Permanent"
-				time.unban = "Never"
-			else
-				time.duration 	= MBSyncTbl.duration.." minutes "
-				time.unban		= os.date( "%H:%M - %d/%m/%Y" ,(MBSyncTbl.duration + MBSyncTbl.ban_date))
+
+	hook.Add( "PlayerInitialSpawn", "MSyncBanCheckBackup", function(ply)
+		local MBSyncTbl = MSync.CheckIfBanned(ply:SteamID(), function(banTable)
+			if banTable then
+				print("[MBSync] Backup check: " .. ply:GetName() .. " is banned!")
+				ply:Kick(MSync.GetBannedMessage(MBSyncTbl.reason, MBSyncTbl.ban_date, MBSyncTbl.duration, MBSyncTbl.staff_name))
 			end
-			print("[MBSync] Backup check: "..ply:GetName().." is banned!")
-			ply:Kick(
-				"[MBSync] You are banned!\n" ..
-				"Reason: " .. MBSyncTbl.reason .. "\n" ..
-				"Duration: " .. time.duration .. "\n" ..
-				"Banned by: " .. MBSyncTbl.admin .. "\n" ..
-				"Unban date: " .. time.unban
-			)
-		end
+		end)
 	end)
 end

--- a/lua/msync/msync_hooks.lua
+++ b/lua/msync/msync_hooks.lua
@@ -3,6 +3,8 @@ if(table.HasValue(MSync.Settings.EnabledModules,"MRSync"))then
 	hook.Add("PlayerDisconnected", "MRSyncSaveUser", MSync.SaveRank)
 	hook.Add("ShutDown", "MRSyncSaveAllUsers", MSync.SaveAllRanks)
 end
+
+-- TODO lot of duplicate code
 if(table.HasValue(MSync.Settings.EnabledModules,"MBSync"))then
 	hook.Add( "CheckPassword", "MSyncBanCheck", function( steamID64 )
 		local MBSyncTbl = MSync.CheckIfBanned(util.SteamIDFrom64(steamID64))
@@ -14,11 +16,17 @@ if(table.HasValue(MSync.Settings.EnabledModules,"MBSync"))then
 				time.duration = "Permanent"
 				time.unban = "Never"
 			else
-				time.duration 	= MBSyncTbl.duration.." Minutes "
+				time.duration 	= MBSyncTbl.duration.." minutes "
 				time.unban		= os.date( "%H:%M - %d/%m/%Y" ,(MBSyncTbl.duration + MBSyncTbl.ban_date))
 			end
 			
-			return false , ("[MBSync] You are Banned! \n Reason: "..MBSyncTbl.reason.."\n Duration: "..time.duration.." \n Banned by: "..MBSyncTbl.admin.." \n Unban Date: "..time.unban)
+			return false , (
+				"[MBSync] You are banned!\n" ..
+				"Reason: " .. MBSyncTbl.reason .. "\n" ..
+				"Duration: " .. time.duration .. "\n" ..
+				"Banned by: " .. MBSyncTbl.admin .. "\n" ..
+				"Unban date: " .. time.unban
+			)
 		end
 	end)
 	
@@ -26,17 +34,23 @@ if(table.HasValue(MSync.Settings.EnabledModules,"MBSync"))then
 		local MBSyncTbl = MSync.CheckIfBanned(ply:SteamID())
 		local time = {}
 		if (MBSyncTbl==true) then
-			print("[MBSync] Backup Check: "..ply:GetName().." is not Banned!")
+			print("[MBSync] Backup check: "..ply:GetName().." is not banned!")
 		else
 			if(MBSyncTbl.duration<=0)then
 				time.duration = "Permanent"
 				time.unban = "Never"
 			else
-				time.duration 	= MBSyncTbl.duration.." Minutes "
+				time.duration 	= MBSyncTbl.duration.." minutes "
 				time.unban		= os.date( "%H:%M - %d/%m/%Y" ,(MBSyncTbl.duration + MBSyncTbl.ban_date))
 			end
-			print("[MBSync] Backup Check: "..ply:GetName().." is Banned!")
-			ply:Kick("[MBSync] You are Banned! \nReason: "..MBSyncTbl.reason.."\nDuration: "..time.duration.." \nBanned by: "..MBSyncTbl.admin.." \nUnban Date: "..time.unban)
+			print("[MBSync] Backup check: "..ply:GetName().." is banned!")
+			ply:Kick(
+				"[MBSync] You are banned!\n" ..
+				"Reason: " .. MBSyncTbl.reason .. "\n" ..
+				"Duration: " .. time.duration .. "\n" ..
+				"Banned by: " .. MBSyncTbl.admin .. "\n" ..
+				"Unban date: " .. time.unban
+			)
 		end
 	end)
 end

--- a/lua/msync/mysql_main.lua
+++ b/lua/msync/mysql_main.lua
@@ -5,8 +5,8 @@
 if(file.Exists( "bin/gmsv_mysqloo_linux.dll", "LUA" ) or file.Exists( "bin/gmsv_mysqloo_win32.dll", "LUA" ))then
 	MSync = MSync or {}
 	-- TODO move this into some shared config file or somewhere
-	MSync.TableNameBans = "mbsync_testing"
-	MSync.TableNameRanks = "mrsync_testing"
+	MSync.TableNameBans = "mbsync"
+	MSync.TableNameRanks = "mrsync"
 	local ulxsql = ulxsql or {}
 	local ULXDB = ULXDB or {}
 

--- a/lua/msync/mysql_main.lua
+++ b/lua/msync/mysql_main.lua
@@ -2,6 +2,9 @@
 -- Web: www.Aperture-Hosting.de
 -- Contact: webmaster@aperture-hosting.de
 
+-- TODO move this into settings or somewhere
+local tableName = "mrsync"
+
 if(file.Exists( "bin/gmsv_mysqloo_linux.dll", "LUA" ) or file.Exists( "bin/gmsv_mysqloo_win32.dll", "LUA" ))then
 	MSync = MSync or {}
 	local ulxsql = ulxsql or {}
@@ -32,36 +35,33 @@ if(file.Exists( "bin/gmsv_mysqloo_linux.dll", "LUA" ) or file.Exists( "bin/gmsv_
 	
 	function checkQuery(query)
 		local playerInfo = query:getData()
-		if playerInfo[1] ~= nil then
-					return true
-		else
-					return false
-		end
+		return playerInfo[1] ~= nil
 	end
 	 
 	local num_rows = 0
 	
 	function MSync.checkTable(server)
-			print("[MSync] Connected to database")
-			print("[MSync] Checking database\n")
-			if(table.HasValue(MSync.Settings.EnabledModules,"MRSync"))then
-				local MRSyncCT  = server:query( "CREATE TABLE IF NOT EXISTS `mrsync` (`steamid` varchar(20) NOT NULL, `groups` varchar(30) NOT NULL, `servergroup` varchar(30) NOT NULL)" )
-				MRSyncCT.onError = function(Q,Err) print("[MRSync] Failed to create table: " .. Err) end
-				MRSyncCT:start()
-			end
-			if(table.HasValue(MSync.Settings.EnabledModules,"MBSync"))then
-				// SteamID; Banning Admin;Reason;Ban Date;Duration
-				local MBSyncCT  = server:query( "CREATE TABLE IF NOT EXISTS `mbsync` (`steamid` varchar(20) NOT NULL,`nickname` varchar(30) NOT NULL, `admin` varchar(30) NOT NULL, `reason` varchar(30) NOT NULL,`ban_date` INT NOT NULL ,`duration` INT NOT NULL, UNIQUE KEY `steamid_UNIQUE` (`steamid`))" )
-				MBSyncCT.onError = function(Q,Err) print("[MBSync] Failed to create table: " .. Err) end
-				MBSyncCT:start()
-			end
-			/*if(table.HasValue(MSync.Settings.EnabledModules,"MPSync"))then
-				//Ranks
-				//Permissions
-				//Rank ID and Permission ID
-				//Servers
-				//Server id and Permission ID
-			end*/
+		print("[MSync] Connected to database")
+		print("[MSync] Checking database\n")
+		-- TODO move into the SQL part
+		if(table.HasValue(MSync.Settings.EnabledModules,"MRSync"))then
+			local MRSyncCT  = server:query( "CREATE TABLE IF NOT EXISTS `" .. tableName .. "` (`steamid` varchar(20) NOT NULL, `groups` varchar(30) NOT NULL, `servergroup` varchar(30) NOT NULL)" )
+			MRSyncCT.onError = function(Q,Err) print("[MRSync] Failed to create table: " .. Err) end
+			MRSyncCT:start()
+		end
+		if(table.HasValue(MSync.Settings.EnabledModules,"MBSync"))then
+			// SteamID; Banning Admin;Reason;Ban Date;Duration
+			local MBSyncCT  = server:query( "CREATE TABLE IF NOT EXISTS `" .. tableName .. "` (`steamid` varchar(20) NOT NULL,`nickname` varchar(30) NOT NULL, `admin` varchar(30) NOT NULL, `reason` varchar(30) NOT NULL,`ban_date` INT NOT NULL ,`duration` INT NOT NULL, UNIQUE KEY `steamid_UNIQUE` (`steamid`))" )
+			MBSyncCT.onError = function(Q,Err) print("[MBSync] Failed to create table: " .. Err) end
+			MBSyncCT:start()
+		end
+		/*if(table.HasValue(MSync.Settings.EnabledModules,"MPSync"))then
+			//Ranks
+			//Permissions
+			//Rank ID and Permission ID
+			//Servers
+			//Server id and Permission ID
+		end*/
 	end
 	 
 	mrsyncconnect()

--- a/lua/msync/mysql_main.lua
+++ b/lua/msync/mysql_main.lua
@@ -9,84 +9,142 @@ if(file.Exists( "bin/gmsv_mysqloo_linux.dll", "LUA" ) or file.Exists( "bin/gmsv_
 	MSync.TableNameRanks = "mrsync_testing"
 	local ulxsql = ulxsql or {}
 	local ULXDB = ULXDB or {}
-	
+
 	function MSync.Connect()
 		require("mysqloo")
 		MSync.DB = mysqloo.connect(MSync.Settings.mysql.Host, MSync.Settings.mysql.Username, MSync.Settings.mysql.Password, MSync.Settings.mysql.Database, MSync.Settings.mysql.Port)
 		MSync.DB.onConnected = MSync.checkTables
 		MSync.DB.onConnectionFailed = MSync.DBError
 		MSync.DB:connect()
-		
 	end
 
 	function MSync.DBError()
 		Msg("[MSync] Connection to database failed\n")
 	end
-	
+
 	-- TODO find usages and replace them with query:hasMoreResults()
 	function checkQuery(query)
 		local playerInfo = query:getData()
 		return playerInfo[1] ~= nil
 	end
-	 
-	local num_rows = 0
-	
+
 	function MSync.checkTables(server)
 		print("[MSync] Connected to database")
 		print("[MSync] Checking database")
+
+		local transaction = server:createTransaction()
+
 		if(table.HasValue(MSync.Settings.EnabledModules, "MRSync")) then
-			local MRSyncCT  = server:prepare([[
-				CREATE TABLE IF NOT EXISTS `]] .. MSync.TableNameRanks .. [[` (
-					`steamid` varchar(20) NOT NULL,
-					`groups` varchar(30) NOT NULL,
-					`servergroup` varchar(30) NOT NULL
-				)
-			]])
-			MRSyncCT.onError = function(Q, Err) print("[MRSync] Failed to create table: " .. Err) end
-			MRSyncCT:start()
+			if (MSync.Settings.DBVersion < 1.0) then
+				local MRSyncCT  = server:query([[
+					CREATE TABLE IF NOT EXISTS `]] .. MSync.TableNameRanks .. [[` (
+						`steamid` varchar(20) NOT NULL,
+						`groups` varchar(30) NOT NULL,
+						`servergroup` varchar(30) NOT NULL
+					)
+				]])
+				transaction:addQuery(MRSyncCT)
+			end
 		end
+
 		if(table.HasValue(MSync.Settings.EnabledModules, "MBSync")) then
-			local MBSyncCT  = server:prepare([[
-				CREATE TABLE IF NOT EXISTS `]] .. MSync.TableNameBans .. [[` (
-					`steamid` varchar(20) NOT NULL,
-					`nickname` varchar(30) NOT NULL,
-					`admin` varchar(30) NOT NULL,
-					`reason` varchar(30) NOT NULL,
-					`ban_date` INT NOT NULL,
-					`duration` INT NOT NULL,
-					UNIQUE KEY `steamid_UNIQUE` (`steamid`)
-				)
-			]])
-			MBSyncCT.onError = function(Q, Err) print("[MBSync] Failed to create table: " .. Err) end
-			MBSyncCT:start()
+
+			if (MSync.Settings.DBVersion < 1.0) then
+				local MBSyncCT  = server:query([[
+					CREATE TABLE IF NOT EXISTS `]] .. MSync.TableNameBans .. [[` (
+						`steamid` varchar(20) NOT NULL,
+						`nickname` varchar(30) NOT NULL,
+						`admin` varchar(30) NOT NULL,
+						`reason` varchar(30) NOT NULL,
+						`ban_date` INT NOT NULL,
+						`duration` INT NOT NULL,
+						UNIQUE KEY `steamid_UNIQUE` (`steamid`)
+					)
+				]])
+				transaction:addQuery(MBSyncCT)
+				print("[MBSync] Going to update DB structure to v1.0")
+			end
+
+			if (MSync.Settings.DBVersion < 1.1) then
+				-- Add `admin_sid` column if it doesn't already exist.
+				local column = 'admin_sid'
+				local updateQuery = server:query([[
+					SET @preparedStatement = IF(
+					    (SELECT COUNT(*)
+					        FROM INFORMATION_SCHEMA.COLUMNS
+					        WHERE table_name = ']] .. MSync.TableNameBans .. [['
+					        AND table_schema = DATABASE()
+					        AND column_name = ']] .. column .. [['
+					    ) > 0,
+					    'SELECT 1;',
+					    'ALTER TABLE `]] .. MSync.TableNameBans .. [[` ADD `]] .. column .. [[` VARCHAR(20) AFTER `nickname`;'
+					);
+					PREPARE alterIfNotExists FROM @preparedStatement;
+					EXECUTE alterIfNotExists;
+					DEALLOCATE PREPARE alterIfNotExists;
+				]])
+				transaction:addQuery(updateQuery)
+				print("[MBSync] Going to update DB structure to v1.1")
+			end
+
+			if (MSync.Settings.DBVersion < 1.2) then
+				-- Rename some columns, allow NULLs, increase VARCHAR sizes and change INTs to unsigned
+				local updateQuery = server:query([[
+					ALTER TABLE `]] .. MSync.TableNameBans .. [[`
+						CHANGE COLUMN `nickname` `name` VARCHAR(32),
+						CHANGE COLUMN `admin` `staff_name` VARCHAR(32) NOT NULL,
+						CHANGE COLUMN `admin_sid` `staff_steamid` VARCHAR(20),
+						MODIFY `reason` VARCHAR(255) NOT NULL,
+						MODIFY `ban_date` INT UNSIGNED NOT NULL,
+						MODIFY `duration` INT UNSIGNED NOT NULL;
+				]])
+				transaction:addQuery(updateQuery)
+				print("[MBSync] Going to update DB structure to v1.2")
+			end
+
+			if (MSync.Settings.DBVersion < 1.3) then
+				-- Drop the unique on `steamid`, add auto-incrementing `id` and set it as new PK
+				local updateQuery = server:query([[
+					ALTER TABLE `]] .. MSync.TableNameBans .. [[`
+						DROP INDEX steamid_UNIQUE,
+						ADD `id` INT PRIMARY KEY AUTO_INCREMENT FIRST,
+						ADD INDEX steamid_INDEX (`steamid`);
+				]])
+				transaction:addQuery(updateQuery)
+				print("[MBSync] Going to update DB structure to v1.3")
+			end
+
 		end
-		/*if(table.HasValue(MSync.Settings.EnabledModules, "MPSync")) then
+		--[[if(table.HasValue(MSync.Settings.EnabledModules, "MPSync")) then
 			//Ranks
 			//Permissions
 			//Rank ID and Permission ID
 			//Servers
 			//Server id and Permission ID
-		end*/
+		end]]--
+
+		-- Start the transaction, if any queries were added to it
+		if transaction:getQueries() ~= nil then
+			transaction.onError = function (tr, err) print("[MSync] Database creation/update failed: " .. err) end
+			transaction.onSuccess = function ()
+				MSync.Settings.DBVersion = MSync.DBVersion
+				MSync.SaveSettings()
+				print("[MSync] Database upgrade successful, current DB schema version " .. MSync.DBVersion)
+			end
+			transaction:start()
+		end
 	end
-	
+
 	MSync.Connect()
-	
+
 	include( "msync/mrsync_sql.lua" )
 	include( "msync/mbsync_sql.lua" )
 	include( "msync/mbsync_chat.lua" )
 	include( "msync/msync_hooks.lua" )
-	
+
 else
 	print('[MSync] WARNING! You need MySQLoo v9 or higher for this addon to work!')
 	print('[MSync] Get it from here: https://facepunch.com/showthread.php?t=1515853')
 	print('[MSync] Here are installation instructions:')
 	print('[MSync] https://help.serenityservers.net/index.php?title=Garrysmod:How_to_install_mysqloo_or_tmysql')
 end
-
-		
-
-		 
-
-		 
-		 
-

--- a/lua/msync/mysql_main.lua
+++ b/lua/msync/mysql_main.lua
@@ -21,13 +21,13 @@ if(file.Exists( "bin/gmsv_mysqloo_linux.dll", "LUA" ) or file.Exists( "bin/gmsv_
 		require("mysqloo")
 		MSync.DB = mysqloo.connect(MSync.Settings.mysql.Host, MSync.Settings.mysql.Username, MSync.Settings.mysql.Password, MSync.Settings.mysql.Database, MSync.Settings.mysql.Port)
 		MSync.DB.onConnected = function() MSync.SQLStatus = "Connected (C1)" end
-		MSync.DB.onConnectionFailed = function() MSync.SQLStatus = "Connection Failed (C2)" end
+		MSync.DB.onConnectionFailed = function() MSync.SQLStatus = "Connection failed (C2)" end
 		MSync.DB:connect()
 		
 	end
 	*/
 	function MSync.DBError()
-			Msg("[MSync] Connection to Failed\n")
+			Msg("[MSync] Connection to database failed\n")
 	end
 	
 	function checkQuery(query)
@@ -42,17 +42,17 @@ if(file.Exists( "bin/gmsv_mysqloo_linux.dll", "LUA" ) or file.Exists( "bin/gmsv_
 	local num_rows = 0
 	
 	function MSync.checkTable(server)
-			print("[MSync] Connected to Database")
+			print("[MSync] Connected to database")
 			print("[MSync] Checking database\n")
 			if(table.HasValue(MSync.Settings.EnabledModules,"MRSync"))then
 				local MRSyncCT  = server:query( "CREATE TABLE IF NOT EXISTS `mrsync` (`steamid` varchar(20) NOT NULL, `groups` varchar(30) NOT NULL, `servergroup` varchar(30) NOT NULL)" )
-				MRSyncCT.onError = function(Q,Err) print("[MRSync] Failed to Create Table: " .. Err) end
+				MRSyncCT.onError = function(Q,Err) print("[MRSync] Failed to create table: " .. Err) end
 				MRSyncCT:start()
 			end
 			if(table.HasValue(MSync.Settings.EnabledModules,"MBSync"))then
 				// SteamID; Banning Admin;Reason;Ban Date;Duration
 				local MBSyncCT  = server:query( "CREATE TABLE IF NOT EXISTS `mbsync` (`steamid` varchar(20) NOT NULL,`nickname` varchar(30) NOT NULL, `admin` varchar(30) NOT NULL, `reason` varchar(30) NOT NULL,`ban_date` INT NOT NULL ,`duration` INT NOT NULL, UNIQUE KEY `steamid_UNIQUE` (`steamid`))" )
-				MBSyncCT.onError = function(Q,Err) print("[MBSync] Failed to Create Table: " .. Err) end
+				MBSyncCT.onError = function(Q,Err) print("[MBSync] Failed to create table: " .. Err) end
 				MBSyncCT:start()
 			end
 			/*if(table.HasValue(MSync.Settings.EnabledModules,"MPSync"))then
@@ -72,9 +72,9 @@ if(file.Exists( "bin/gmsv_mysqloo_linux.dll", "LUA" ) or file.Exists( "bin/gmsv_
 	include( "msync/msync_hooks.lua" )
 	
 else
-	print('[MSync] WARNING! You need MySQLoo for this Script to Run!')
-	print('[MSync] Get it from Here: http://facepunch.hatt.co/showthread.php?t=1357773')
-	print('[MSync] Here is an Install Instruction:')
+	print('[MSync] WARNING! You need MySQLoo for this addon to work!')
+	print('[MSync] Get it from here: https://facepunch.com/showthread.php?t=1515853')
+	print('[MSync] Here are installation instructions:')
 	print('[MSync] https://help.serenityservers.net/index.php?title=Garrysmod:How_to_install_mysqloo_or_tmysql')
 end
 

--- a/lua/msync/mysql_main.lua
+++ b/lua/msync/mysql_main.lua
@@ -1,8 +1,8 @@
---Script Made by: Aperture-Hosting
+-- Script Made by: Aperture-Hosting, edited by Princess Celestia
 -- Web: www.Aperture-Hosting.de
 -- Contact: webmaster@aperture-hosting.de
 
--- TODO move this into settings or somewhere
+-- TODO move this into some shared config file or somewhere
 local tableName = "mrsync"
 
 if(file.Exists( "bin/gmsv_mysqloo_linux.dll", "LUA" ) or file.Exists( "bin/gmsv_mysqloo_win32.dll", "LUA" ))then
@@ -43,19 +43,34 @@ if(file.Exists( "bin/gmsv_mysqloo_linux.dll", "LUA" ) or file.Exists( "bin/gmsv_
 	function MSync.checkTable(server)
 		print("[MSync] Connected to database")
 		print("[MSync] Checking database\n")
-		-- TODO move into the SQL part
-		if(table.HasValue(MSync.Settings.EnabledModules,"MRSync"))then
-			local MRSyncCT  = server:query( "CREATE TABLE IF NOT EXISTS `" .. tableName .. "` (`steamid` varchar(20) NOT NULL, `groups` varchar(30) NOT NULL, `servergroup` varchar(30) NOT NULL)" )
-			MRSyncCT.onError = function(Q,Err) print("[MRSync] Failed to create table: " .. Err) end
+		if(table.HasValue(MSync.Settings.EnabledModules, "MRSync")) then
+			local MRSyncCT  = server:prepare([[
+				CREATE TABLE IF NOT EXISTS `]] .. tableName .. [[` (
+					`steamid` varchar(20) NOT NULL,
+					`groups` varchar(30) NOT NULL,
+					`servergroup` varchar(30) NOT NULL
+				)
+			]])
+			MRSyncCT.onError = function(Q, Err) print("[MRSync] Failed to create table: " .. Err) end
 			MRSyncCT:start()
 		end
-		if(table.HasValue(MSync.Settings.EnabledModules,"MBSync"))then
+		if(table.HasValue(MSync.Settings.EnabledModules, "MBSync")) then
 			// SteamID; Banning Admin;Reason;Ban Date;Duration
-			local MBSyncCT  = server:query( "CREATE TABLE IF NOT EXISTS `" .. tableName .. "` (`steamid` varchar(20) NOT NULL,`nickname` varchar(30) NOT NULL, `admin` varchar(30) NOT NULL, `reason` varchar(30) NOT NULL,`ban_date` INT NOT NULL ,`duration` INT NOT NULL, UNIQUE KEY `steamid_UNIQUE` (`steamid`))" )
-			MBSyncCT.onError = function(Q,Err) print("[MBSync] Failed to create table: " .. Err) end
+			local MBSyncCT  = server:prepare([[
+				CREATE TABLE IF NOT EXISTS `]] .. tableName .. [[` (
+					`steamid` varchar(20) NOT NULL,
+					`nickname` varchar(30) NOT NULL,
+					`admin` varchar(30) NOT NULL,
+					`reason` varchar(30) NOT NULL,
+					`ban_date` INT NOT NULL,
+					`duration` INT NOT NULL,
+					UNIQUE KEY `steamid_UNIQUE` (`steamid`)
+				)
+			]])
+			MBSyncCT.onError = function(Q, Err) print("[MBSync] Failed to create table: " .. Err) end
 			MBSyncCT:start()
 		end
-		/*if(table.HasValue(MSync.Settings.EnabledModules,"MPSync"))then
+		/*if(table.HasValue(MSync.Settings.EnabledModules, "MPSync")) then
 			//Ranks
 			//Permissions
 			//Rank ID and Permission ID

--- a/lua/ulx/xgui/server/sv_msync_gui.lua
+++ b/lua/ulx/xgui/server/sv_msync_gui.lua
@@ -1,4 +1,4 @@
-ULib.ucl.registerAccess(	"xgui_msync", "superadmin", "Allows to see and Change the MRSync Settings.", "XGUI" )
+ULib.ucl.registerAccess(	"xgui_msync", "superadmin", "Allows to see and change MSync Settings.", "XGUI" )
 local mrsync = {}
 function mrsync.Init()
 	xgui.addDataType( "MSync-Settings", function() return MSync.Settings end, "xgui_msync", 0, -10 )

--- a/lua/ulx/xgui/settings/cl_msync_gui.lua
+++ b/lua/ulx/xgui/settings/cl_msync_gui.lua
@@ -2,328 +2,323 @@ xgui.prepareDataType( "MSync-Settings" )
 
 include( "autorun/client/cl_msync_util.lua" )
 
+MSync = MSync or {}
+MSync.Modules = MSync.Modules or {}
+MSync.MySQL	= MSync.MySQL or {}
+MSync.MRSync = MSync.MRSync or {}
+MSync.MBSync = MSync.MBSync or {}
+local MSyncVars = {}
 
-	MSync = MSync or {}
-	MSync.Modules = MSync.Modules or {}
-	MSync.MySQL	= MSync.MySQL or {}
-	MSync.MRSync = MSync.MRSync or {}
-	MSync.MBSync = MSync.MBSync or {}
-	local MSyncVars = {}
-	
 if(ULib.ucl.query(	LocalPlayer(),"xgui_msync"))then
 	MSync.GetSettings()
 end
-	function MSync.Modules.init()
-		MSync.Modules.enabledModulesList = xlib.makelistview{ parent=MSync.back, x=180, y=30, w=150, h=200 }
-		MSync.Modules.disable = xlib.makebutton{ parent=MSync.back, x=340, y=120, w=20, h=20, label="->", disabled=false }
-		MSync.Modules.enable = xlib.makebutton{ parent=MSync.back, x=340, y=160, w=20, h=20, label="<-", disabled=false }	
-		MSync.Modules.disabledModulesList = xlib.makelistview{ parent=MSync.back, x=370, y=30, w=150, h=200 }	
-		MSync.Modules.enabledModulesList:AddColumn( "Enabled Modules" )
-		MSync.Modules.disabledModulesList:AddColumn( "Disabled Modules" )
-		MSync.Modules.enabledModulesList:SetMultiSelect( false )
-		MSync.Modules.disabledModulesList:SetMultiSelect( false )
-		MSync.Modules.DescriptionText = xlib.makelabel{ x=180, y=235, w=300, wordwrap=true, label="To enable a module, select the module in the Disabled modules list and press '<-'. To disable a module, select it in the Enabled Modules list and press '->'.", parent=MSync.back }
-	end
 
-	function MSync.MySQL.init()
-		MSync.MySQL.text 			= xlib.makelabel{ x=165, y=13, label="MySQL Settings", parent=MSync.back }
-		MSync.MySQL.Hosttext 		= xlib.makelabel{ x=165, y=30, label="Host/IP:", parent=MSync.back }
-		MSync.MySQL.Host 	 		= xlib.maketextbox{ parent=MSync.back, x=165, y=45, w=160, h=25, disabled=false, visible=true}
-		MSync.MySQL.Porttext 		= xlib.makelabel{ x=165, y=75, label="Port:", parent=MSync.back }
-		MSync.MySQL.Port 	 		= xlib.maketextbox{ parent=MSync.back, x=165, y=90, w=160, h=25, disabled=false, visible=true}
-		MSync.MySQL.Usernametext 	= xlib.makelabel{ x=165, y=120, label="Username:", parent=MSync.back }
-		MSync.MySQL.Username 		= xlib.maketextbox{ parent=MSync.back, x=165, y=135, w=160, h=25, disabled=false, visible=true}
-		MSync.MySQL.Passwordtext 	= xlib.makelabel{ x=165, y=165, label="Password:", parent=MSync.back }
-		MSync.MySQL.Password 		= xlib.maketextbox{ parent=MSync.back, x=165, y=180, w=160, h=25, disabled=false, visible=true}
-		MSync.MySQL.Databasetext 	= xlib.makelabel{ x=165, y=210, label="Database:", parent=MSync.back }
-		MSync.MySQL.Database 		= xlib.maketextbox{ parent=MSync.back, x=165, y=225, w=160, h=25, disabled=false, visible=true}
-		MSync.MySQL.Servergrptext 	= xlib.makelabel{ x=165, y=255, label="Servergroup:", parent=MSync.back }
-		MSync.MySQL.Servergrp 		= xlib.maketextbox{ parent=MSync.back, x=165, y=270, w=160, h=25, disabled=false, visible=true}
-		MSync.MySQL.DescriptionText = xlib.makelabel{ x=350, y=10, w=170, wordwrap=true, label="Set your MySQL settings here.\nHOST: Hostname or IP address of the SQL server.\nPORT: Port of the MySQL server.\nUSERNAME: Username for the access to the database.\nPASSWORD: Password for the MySQL user.\nDATABASE: Name of the MySQL database to use.\nSERVERGROUP: Name of the server group this server belongs to (for example DarkRP or sandbox).", parent=MSync.back }
-		
-		/* Currently not Working! Stay tuned for Updates!
-		MSync.MySQL.connectText		= xlib.makelabel{ x=360, y=265, label="Status: Unknown", parent=MSync.back }
-		MSync.MySQL.connectButton 	= xlib.makebutton{ parent=MSync.back, x=360, y=280, w=100, h=15, label="CONNECT", disabled=false }
-		*/
-		
+function MSync.Modules.init()
+	MSync.Modules.enabledModulesList = xlib.makelistview{ parent=MSync.back, x=180, y=30, w=150, h=200 }
+	MSync.Modules.disable = xlib.makebutton{ parent=MSync.back, x=340, y=120, w=20, h=20, label="->", disabled=false }
+	MSync.Modules.enable = xlib.makebutton{ parent=MSync.back, x=340, y=160, w=20, h=20, label="<-", disabled=false }
+	MSync.Modules.disabledModulesList = xlib.makelistview{ parent=MSync.back, x=370, y=30, w=150, h=200 }
+	MSync.Modules.enabledModulesList:AddColumn( "Enabled Modules" )
+	MSync.Modules.disabledModulesList:AddColumn( "Disabled Modules" )
+	MSync.Modules.enabledModulesList:SetMultiSelect( false )
+	MSync.Modules.disabledModulesList:SetMultiSelect( false )
+	MSync.Modules.DescriptionText = xlib.makelabel{ x=180, y=235, w=300, wordwrap=true, label="To enable a module, select the module in the Disabled modules list and press '<-'. To disable a module, select it in the Enabled Modules list and press '->'.", parent=MSync.back }
+end
+
+function MSync.MySQL.init()
+	MSync.MySQL.text 			= xlib.makelabel{ x=165, y=13, label="MySQL Settings", parent=MSync.back }
+	MSync.MySQL.Hosttext 		= xlib.makelabel{ x=165, y=30, label="Host/IP:", parent=MSync.back }
+	MSync.MySQL.Host 	 		= xlib.maketextbox{ parent=MSync.back, x=165, y=45, w=160, h=25, disabled=false, visible=true}
+	MSync.MySQL.Porttext 		= xlib.makelabel{ x=165, y=75, label="Port:", parent=MSync.back }
+	MSync.MySQL.Port 	 		= xlib.maketextbox{ parent=MSync.back, x=165, y=90, w=160, h=25, disabled=false, visible=true}
+	MSync.MySQL.Usernametext 	= xlib.makelabel{ x=165, y=120, label="Username:", parent=MSync.back }
+	MSync.MySQL.Username 		= xlib.maketextbox{ parent=MSync.back, x=165, y=135, w=160, h=25, disabled=false, visible=true}
+	MSync.MySQL.Passwordtext 	= xlib.makelabel{ x=165, y=165, label="Password:", parent=MSync.back }
+	MSync.MySQL.Password 		= xlib.maketextbox{ parent=MSync.back, x=165, y=180, w=160, h=25, disabled=false, visible=true}
+	MSync.MySQL.Databasetext 	= xlib.makelabel{ x=165, y=210, label="Database:", parent=MSync.back }
+	MSync.MySQL.Database 		= xlib.maketextbox{ parent=MSync.back, x=165, y=225, w=160, h=25, disabled=false, visible=true}
+	MSync.MySQL.Servergrptext 	= xlib.makelabel{ x=165, y=255, label="Servergroup:", parent=MSync.back }
+	MSync.MySQL.Servergrp 		= xlib.maketextbox{ parent=MSync.back, x=165, y=270, w=160, h=25, disabled=false, visible=true}
+	MSync.MySQL.DescriptionText = xlib.makelabel{ x=350, y=10, w=170, wordwrap=true, label="Set your MySQL settings here.\nHOST: Hostname or IP address of the SQL server.\nPORT: Port of the MySQL server.\nUSERNAME: Username for the access to the database.\nPASSWORD: Password for the MySQL user.\nDATABASE: Name of the MySQL database to use.\nSERVERGROUP: Name of the server group this server belongs to (for example DarkRP or sandbox).", parent=MSync.back }
+
+	--[[ Currently not Working! Stay tuned for Updates!
+	MSync.MySQL.connectText		= xlib.makelabel{ x=360, y=265, label="Status: Unknown", parent=MSync.back }
+	MSync.MySQL.connectButton 	= xlib.makebutton{ parent=MSync.back, x=360, y=280, w=100, h=15, label="CONNECT", disabled=false }
+	--]]
+
+	MSync.MySQL.Host:SetText(MSync.LocalSettings.mysql.Host)
+	MSync.MySQL.Port:SetText(MSync.LocalSettings.mysql.Port)
+	MSync.MySQL.Username:SetText(MSync.LocalSettings.mysql.Username)
+	MSync.MySQL.Password:SetText(MSync.LocalSettings.mysql.Password)
+	MSync.MySQL.Database:SetText(MSync.LocalSettings.mysql.Database)
+	MSync.MySQL.Servergrp:SetText(MSync.LocalSettings.Servergroup)
+end
+
+function MSync.MRSync.init()
+	MSync.MRSync.text 					= xlib.makelabel{ x=160, y=10, label="MRSync Settings", parent=MSync.back }
+	MSync.MRSync.IgnoreTable 			= xlib.makelistview{ parent=MSync.back, x=160, y=30, w=150, h=180 }
+	MSync.MRSync.AllServerTable 		= xlib.makelistview{ parent=MSync.back, x=320, y=30, w=150, h=180 }
+
+	MSync.MRSync.AddIgnoreButton 		= xlib.makebutton{ parent=MSync.back, x=280, y=220, w=15, h=25, label="+", disabled=false }
+	MSync.MRSync.RemoveIgnoreButton 	= xlib.makebutton{ parent=MSync.back, x=295, y=220, w=15, h=25, label="-", disabled=false }
+
+	MSync.MRSync.AddAllServerButton 	= xlib.makebutton{ parent=MSync.back, x=440, y=220, w=15, h=25, label="+", disabled=false }
+	MSync.MRSync.RemoveAllServerButton 	= xlib.makebutton{ parent=MSync.back, x=455, y=220, w=15, h=25, label="-", disabled=false }
+
+	MSync.MRSync.IgnoreTextBox			= xlib.maketextbox{ parent=MSync.back, x=160, y=220, w=120, h=25, disabled=false, visible=true}
+	MSync.MRSync.AllServerTextBox		= xlib.maketextbox{ parent=MSync.back, x=320, y=220, w=120, h=25, disabled=false, visible=true}
+
+	MSync.MRSync.Descriptiontext 		= xlib.makelabel{ x=475, y=30, w=100, wordwrap=true, label="Ignored ranks: This is a list of ranks which are not going to be saved in the MySQL table.\nAll servers ranks: These are ranks which ignore the Servergroup and are synced across all servers", parent=MSync.back }
+	MSync.MRSync.Descriptiontext2 		= xlib.makelabel{ x=160, y=250, w=340, wordwrap=true, label="Description: Enter the rank and press '+' to add it to the list. To remove an entry, select it in the table and press '-'.", parent=MSync.back }
+
+	MSync.MRSync.IgnoreTable:AddColumn( "Ignored ranks" )
+	MSync.MRSync.AllServerTable:AddColumn( "All servers ranks" )
+	MSync.MRSync.IgnoreTable:SetMultiSelect( false )
+	MSync.MRSync.AllServerTable:SetMultiSelect( false )
+end
+
+function MSync.MBSync.init()
+	MSync.MBSync.Table				= xlib.makelistview{ parent=MSync.back, x=160, y=35, w=400, h=220 }
+
+	MSync.MBSync.Table:AddColumn( "Name/SteamID" )
+	MSync.MBSync.Table:AddColumn( "Banned by" )
+	MSync.MBSync.Table:AddColumn( "Unban date" )
+	MSync.MBSync.Table:AddColumn( "Reason" )
+	MSync.MBSync.SearchBox			= xlib.maketextbox{ parent=MSync.back, x=160, y=5, w=150, h=25, disabled=false, visible=true}
+	MSync.MBSync.Sync				= xlib.makebutton{ parent=MSync.back, x=370, y=5, w=50, h=25, label="Sync", disabled=false }
+	MSync.MBSync.SearchButton		= xlib.makebutton{ parent=MSync.back, x=315, y=5, w=50, h=25, label="Search", disabled=false }
+	MSync.MBSync.Description		= xlib.makelabel{ x=425, y=5, w=150, wordwrap=true, label="Press 'Sync' to retrieve the bans.", parent=MSync.back }
+
+end
+
+MSync.back = xlib.makepanel{ parent=xgui.null }
+MSync.settingList = xlib.makelistview{ parent=MSync.back, x=5, y=5, w=150, h=250 }
+MSync.refreshbutton = xlib.makebutton{ parent=MSync.back, x=360, y=300, w=100, h=25, label="Refresh", disabled=false }
+MSync.savebutton = xlib.makebutton{ parent=MSync.back, x=150, y=300, w=100, h=25, label="Save", disabled=false }
+MSync.resetbutton = xlib.makebutton{ parent=MSync.back, x=255, y=300, w=100, h=25, label="Reset", disabled=false }
+MSync.connectDescription = xlib.makelabel{ x=5, y=260, w=150, wordwrap=true, label="WARNING: You need to restart the server for the changes to take effect.", parent=MSync.back }
+
+MSync.settingList:AddColumn( "MSync - Settings" )
+MSync.settingList:AddLine( "MySQL" )
+MSync.settingList:AddLine( "Modules" )
+AddTable(MSync.LocalSettings.EnabledModules,MSync.settingList)
+MSync.settingList:SetMultiSelect( false )
+
+--------------------------------------------------------------------------------------------------------------------------------------------
+
+MSync.settingList.OnRowSelected = function( self, lineid, line )
+	if line:GetValue(1) == "MySQL" then
+		HidePanel(MSync.Modules)
+		HidePanel(MSync.MRSync)
+		HidePanel(MSync.MBSync)
+		ShowPanel(MSync.MySQL)
 		MSync.MySQL.Host:SetText(MSync.LocalSettings.mysql.Host)
 		MSync.MySQL.Port:SetText(MSync.LocalSettings.mysql.Port)
 		MSync.MySQL.Username:SetText(MSync.LocalSettings.mysql.Username)
 		MSync.MySQL.Password:SetText(MSync.LocalSettings.mysql.Password)
 		MSync.MySQL.Database:SetText(MSync.LocalSettings.mysql.Database)
 		MSync.MySQL.Servergrp:SetText(MSync.LocalSettings.Servergroup)
-	end
 
-	function MSync.MRSync.init()
-		MSync.MRSync.text 					= xlib.makelabel{ x=160, y=10, label="MRSync Settings", parent=MSync.back }
-		MSync.MRSync.IgnoreTable 			= xlib.makelistview{ parent=MSync.back, x=160, y=30, w=150, h=180 }
-		MSync.MRSync.AllServerTable 		= xlib.makelistview{ parent=MSync.back, x=320, y=30, w=150, h=180 }
-		
-		MSync.MRSync.AddIgnoreButton 		= xlib.makebutton{ parent=MSync.back, x=280, y=220, w=15, h=25, label="+", disabled=false }
-		MSync.MRSync.RemoveIgnoreButton 	= xlib.makebutton{ parent=MSync.back, x=295, y=220, w=15, h=25, label="-", disabled=false }
-		
-		MSync.MRSync.AddAllServerButton 	= xlib.makebutton{ parent=MSync.back, x=440, y=220, w=15, h=25, label="+", disabled=false }
-		MSync.MRSync.RemoveAllServerButton 	= xlib.makebutton{ parent=MSync.back, x=455, y=220, w=15, h=25, label="-", disabled=false }
-		
-		MSync.MRSync.IgnoreTextBox			= xlib.maketextbox{ parent=MSync.back, x=160, y=220, w=120, h=25, disabled=false, visible=true}
-		MSync.MRSync.AllServerTextBox		= xlib.maketextbox{ parent=MSync.back, x=320, y=220, w=120, h=25, disabled=false, visible=true}
-		
-		MSync.MRSync.Descriptiontext 		= xlib.makelabel{ x=475, y=30, w=100, wordwrap=true, label="Ignored ranks: This is a list of ranks which are not going to be saved in the MySQL table.\nAll servers ranks: These are ranks which ignore the Servergroup and are synced across all servers", parent=MSync.back }
-		MSync.MRSync.Descriptiontext2 		= xlib.makelabel{ x=160, y=250, w=340, wordwrap=true, label="Description: Enter the rank and press '+' to add it to the list. To remove an entry, select it in the table and press '-'.", parent=MSync.back }
-		
-		MSync.MRSync.IgnoreTable:AddColumn( "Ignored ranks" ) 
-		MSync.MRSync.AllServerTable:AddColumn( "All servers ranks" ) 
-		MSync.MRSync.IgnoreTable:SetMultiSelect( false )
-		MSync.MRSync.AllServerTable:SetMultiSelect( false )
-	end
+		--[[ Currently not Working! Stay tuned for Updates!
+		MSync.MySQL.connectButton.DoClick = function()
 
-	function MSync.MBSync.init()
-		MSync.MBSync.Table				= xlib.makelistview{ parent=MSync.back, x=160, y=35, w=400, h=220 }
-		
-		MSync.MBSync.Table:AddColumn( "Name/SteamID" ) 
-		MSync.MBSync.Table:AddColumn( "Banned by" ) 
-		MSync.MBSync.Table:AddColumn( "Unban date" ) 
-		MSync.MBSync.Table:AddColumn( "Reason" ) 
-		MSync.MBSync.SearchBox			= xlib.maketextbox{ parent=MSync.back, x=160, y=5, w=150, h=25, disabled=false, visible=true}
-		MSync.MBSync.Sync				= xlib.makebutton{ parent=MSync.back, x=370, y=5, w=50, h=25, label="Sync", disabled=false }
-		MSync.MBSync.SearchButton		= xlib.makebutton{ parent=MSync.back, x=315, y=5, w=50, h=25, label="Search", disabled=false }
-		MSync.MBSync.Description		= xlib.makelabel{ x=425, y=5, w=150, wordwrap=true, label="Press 'Sync' to retrieve the bans.", parent=MSync.back }
-
-	end
-
-
-	MSync.back = xlib.makepanel{ parent=xgui.null }
-	MSync.settingList = xlib.makelistview{ parent=MSync.back, x=5, y=5, w=150, h=250 } 
-	MSync.refreshbutton = xlib.makebutton{ parent=MSync.back, x=360, y=300, w=100, h=25, label="Refresh", disabled=false }
-	MSync.savebutton = xlib.makebutton{ parent=MSync.back, x=150, y=300, w=100, h=25, label="Save", disabled=false }
-	MSync.resetbutton = xlib.makebutton{ parent=MSync.back, x=255, y=300, w=100, h=25, label="Reset", disabled=false }
-	MSync.connectDescription = xlib.makelabel{ x=5, y=260, w=150, wordwrap=true, label="WARNING: You need to restart the server for the changes to take effect.", parent=MSync.back }
-
-
-	MSync.settingList:AddColumn( "MSync - Settings" ) 
-	MSync.settingList:AddLine( "MySQL" )
-	MSync.settingList:AddLine( "Modules" ) 
-	AddTable(MSync.LocalSettings.EnabledModules,MSync.settingList)
-	MSync.settingList:SetMultiSelect( false )
-
-	--------------------------------------------------------------------------------------------------------------------------------------------
-
-
-
-
-	MSync.settingList.OnRowSelected = function( self, lineid, line )
-		if line:GetValue(1) == "MySQL" then
-			HidePanel(MSync.Modules)
-			HidePanel(MSync.MRSync)
-			HidePanel(MSync.MBSync)
-			ShowPanel(MSync.MySQL)
-			MSync.MySQL.Host:SetText(MSync.LocalSettings.mysql.Host)
-			MSync.MySQL.Port:SetText(MSync.LocalSettings.mysql.Port)
-			MSync.MySQL.Username:SetText(MSync.LocalSettings.mysql.Username)
-			MSync.MySQL.Password:SetText(MSync.LocalSettings.mysql.Password)
-			MSync.MySQL.Database:SetText(MSync.LocalSettings.mysql.Database)
-			MSync.MySQL.Servergrp:SetText(MSync.LocalSettings.Servergroup)
-			
-			/* Currently not Working! Stay tuned for Updates!
-			MSync.MySQL.connectButton.DoClick = function()
-				
-			end
-			*/
-		elseif line:GetValue(1) == "MRSync" then
-			HidePanel(MSync.Modules)
-			HidePanel(MSync.MySQL)
-			HidePanel(MSync.MBSync)
-			ShowPanel(MSync.MRSync)
-			
-			MSync.MRSync.AddAllServerButton.DoClick = function()
-				MSync.MRSync.AllServerTable:AddLine(MSync.MRSync.AllServerTextBox:GetText())
-				MSync.MRSync.AllServerTextBox:SetValue("")
-			end
-			
-			MSync.MRSync.RemoveAllServerButton.DoClick = function()
-				if not(MSync.MRSync.AllServerTable:GetSelected()[1]:GetValue(1)==nil)then
-					MSync.MRSync.AllServerTable:RemoveLine(MSync.MRSync.AllServerTable:GetSelectedLine())	
-				else
-					MSync.Chat(Color(255,0,0),"ERROR: No rank selected! (A3)")
-				end
-			end
-			
-			MSync.MRSync.AddIgnoreButton.DoClick = function()
-				MSync.MRSync.IgnoreTable:AddLine(MSync.MRSync.IgnoreTextBox:GetText())
-				MSync.MRSync.IgnoreTextBox:SetValue("")
-			end
-			
-			MSync.MRSync.RemoveIgnoreButton.DoClick = function()
-				if not(MSync.MRSync.IgnoreTable:GetSelected()[1]:GetValue(1)==nil)then
-					MSync.MRSync.IgnoreTable:RemoveLine(MSync.MRSync.IgnoreTable:GetSelectedLine())	
-				else
-					MSync.Chat(Color(255,0,0),"ERROR: No rank selected! (A3)")
-				end
-			end
-		elseif line:GetValue(1) == "MBSync" then
-			HidePanel(MSync.Modules)
-			HidePanel(MSync.MySQL)
-			HidePanel(MSync.MRSync)
-			ShowPanel(MSync.MBSync)
-			
-			MSync.MBSync.Sync.DoClick = function()
-				MSync.GetBans()
-			end
-				
-			
-			MSync.MBSync.SearchButton.DoClick = function()
-				if(MSync.MBSync.SearchBox:GetText()=="")then
-					AddBanTable()
-				else
-					SearchBanTable(MSync.MBSync.SearchBox:GetText())
-				end
-			end
-			
-			MSync.MBSync.Table.OnRowRightClick = function( self, LineID, line )
-				local menu = DermaMenu()
-				menu:SetSkin(xgui.settings.skin)
-				/*menu:AddOption( "Edit ban...", function()
-					if not line:IsValid() then return end
-					xgui.ShowBanWindow( nil, line:GetValue( 5 ), nil, true, xgui.data.bans.cache[LineID] )
-				end )*/
-				menu:AddOption( "Remove", function()
-					if not line:IsValid() then return end
-					MSync.BanTableUnban(MSync.MBSync.Table:GetSelected()[1]:GetValue(1))
-					
-					MSync.MBSync.Table:RemoveLine(MSync.MBSync.Table:GetSelectedLine())
-				end )
-				menu:Open()
-			end
-		elseif line:GetValue(1) == "Modules" then
-			HidePanel(MSync.MySQL)
-			HidePanel(MSync.MRSync)
-			HidePanel(MSync.MBSync)
-			ShowPanel(MSync.Modules)
-			MSync.Modules.enabledModulesList:Clear()
-			MSync.Modules.disabledModulesList:Clear()
-			AddTable(MSync.LocalSettings.EnabledModules,MSync.Modules.enabledModulesList)
-			AddTable(MSync.LocalSettings.DisabledModules,MSync.Modules.disabledModulesList)
-			
-			MSync.Modules.enable.DoClick = function()
-				if not(MSync.Modules.disabledModulesList:GetSelected()[1]:GetValue(1)==nil)then
-					MSync.Modules.enabledModulesList:AddLine( MSync.Modules.disabledModulesList:GetSelected()[1]:GetValue(1))
-					MSync.Modules.disabledModulesList:RemoveLine(MSync.Modules.disabledModulesList:GetSelectedLine())
-				else
-					print("[MSync] ERROR: No line selected! (A3)")
-				end
-			end
-
-			MSync.Modules.disable.DoClick = function()
-				if not(MSync.Modules.enabledModulesList:GetSelected()[1]:GetValue(1)==nil)then
-					MSync.Modules.disabledModulesList:AddLine( MSync.Modules.enabledModulesList:GetSelected()[1]:GetValue(1))
-					MSync.Modules.enabledModulesList:RemoveLine(MSync.Modules.enabledModulesList:GetSelectedLine())
-				else
-					MSync.Chat(Color(255,0,0),"ERROR: No line selected! (A3)")
-				end
-			end
-		
 		end
-	end
+		--]]
+	elseif line:GetValue(1) == "MRSync" then
+		HidePanel(MSync.Modules)
+		HidePanel(MSync.MySQL)
+		HidePanel(MSync.MBSync)
+		ShowPanel(MSync.MRSync)
 
-	MSync.savebutton.DoClick = function()
-		if not(MSync.settingList:GetSelectedLine()==nil)then
-			if(MSync.settingList:GetSelected()[1]:GetValue(1)=="MySQL")then
-				MSync.LocalSettings.mysql ={
-					Host = MSync.MySQL.Host:GetText(),
-					Port = tonumber(MSync.MySQL.Port:GetText()),
-					Database = MSync.MySQL.Database:GetText(),
-					Username = MSync.MySQL.Username:GetText(),
-					Password = MSync.MySQL.Password:GetText()
-				}
-				MSync.LocalSettings.Servergroup = MSync.MySQL.Servergrp:GetText()
-				MSync.SendSettings()
-			elseif(MSync.settingList:GetSelected()[1]:GetValue(1)=="MRSync")then
-				MSync.LocalSettings.mrsync.AllServerRanks = {}
-				MSync.LocalSettings.mrsync.IgnoredRanks = {}
-				
-				for k, line in pairs( MSync.MRSync.IgnoreTable:GetLines()) do
-					if not(table.HasValue(MSync.LocalSettings.mrsync.IgnoredRanks,line:GetValue( 1 )))then
-						table.insert(MSync.LocalSettings.mrsync.IgnoredRanks, line:GetValue( 1 ))
-					end
-				end
-				for k, line in pairs( MSync.MRSync.AllServerTable:GetLines())  do
-					if not(table.HasValue(MSync.LocalSettings.mrsync.AllServerRanks,line:GetValue( 1 )))then
-						table.insert(MSync.LocalSettings.mrsync.AllServerRanks, line:GetValue( 1 ))
-					end
-				end
-				MSync.SendSettings()
-			elseif(MSync.settingList:GetSelected()[1]:GetValue(1)=="MBSync")then
-				
-				MSync.SendSettings()
-			elseif(MSync.settingList:GetSelected()[1]:GetValue(1)=="Modules")then
-				MSync.LocalSettings.EnabledModules = {}
-				MSync.LocalSettings.DisabledModules = {}
-				
-				for k, line in pairs( MSync.Modules.enabledModulesList:GetLines())  do
-					if not(table.HasValue(MSync.LocalSettings.EnabledModules,line:GetValue( 1 )))then
-						table.insert(MSync.LocalSettings.EnabledModules, line:GetValue( 1 ))
-					end
-				end
-				for k, line in pairs( MSync.Modules.disabledModulesList:GetLines())  do
-					if not(table.HasValue(MSync.LocalSettings.DisabledModules,line:GetValue( 1 )))then
-						table.insert(MSync.LocalSettings.DisabledModules, line:GetValue( 1 ))
-					end
-				end
-				MSync.SendSettings()
+		MSync.MRSync.AddAllServerButton.DoClick = function()
+			MSync.MRSync.AllServerTable:AddLine(MSync.MRSync.AllServerTextBox:GetText())
+			MSync.MRSync.AllServerTextBox:SetValue("")
+		end
+
+		MSync.MRSync.RemoveAllServerButton.DoClick = function()
+			if not(MSync.MRSync.AllServerTable:GetSelected()[1]:GetValue(1)==nil)then
+				MSync.MRSync.AllServerTable:RemoveLine(MSync.MRSync.AllServerTable:GetSelectedLine())
+			else
+				MSync.Chat(Color(255,0,0),"ERROR: No rank selected! (A3)")
 			end
-		else
+		end
+
+		MSync.MRSync.AddIgnoreButton.DoClick = function()
+			MSync.MRSync.IgnoreTable:AddLine(MSync.MRSync.IgnoreTextBox:GetText())
+			MSync.MRSync.IgnoreTextBox:SetValue("")
+		end
+
+		MSync.MRSync.RemoveIgnoreButton.DoClick = function()
+			if not(MSync.MRSync.IgnoreTable:GetSelected()[1]:GetValue(1)==nil)then
+				MSync.MRSync.IgnoreTable:RemoveLine(MSync.MRSync.IgnoreTable:GetSelectedLine())
+			else
+				MSync.Chat(Color(255,0,0),"ERROR: No rank selected! (A3)")
+			end
+		end
+	elseif line:GetValue(1) == "MBSync" then
+		HidePanel(MSync.Modules)
+		HidePanel(MSync.MySQL)
+		HidePanel(MSync.MRSync)
+		ShowPanel(MSync.MBSync)
+
+		MSync.MBSync.Sync.DoClick = function()
+			MSync.GetBans()
+		end
+
+
+		MSync.MBSync.SearchButton.DoClick = function()
+			if(MSync.MBSync.SearchBox:GetText()=="")then
+				AddBanTable()
+			else
+				SearchBanTable(MSync.MBSync.SearchBox:GetText())
+			end
+		end
+
+		MSync.MBSync.Table.OnRowRightClick = function( self, LineID, line )
+			local menu = DermaMenu()
+			menu:SetSkin(xgui.settings.skin)
+			--[[menu:AddOption( "Edit ban...", function()
+				if not line:IsValid() then return end
+				xgui.ShowBanWindow( nil, line:GetValue( 5 ), nil, true, xgui.data.bans.cache[LineID] )
+			end )--]]
+			menu:AddOption( "Remove", function()
+				if not line:IsValid() then return end
+				MSync.BanTableUnban(MSync.MBSync.Table:GetSelected()[1]:GetValue(1))
+
+				MSync.MBSync.Table:RemoveLine(MSync.MBSync.Table:GetSelectedLine())
+			end )
+			menu:Open()
+		end
+	elseif line:GetValue(1) == "Modules" then
+		HidePanel(MSync.MySQL)
+		HidePanel(MSync.MRSync)
+		HidePanel(MSync.MBSync)
+		ShowPanel(MSync.Modules)
+		MSync.Modules.enabledModulesList:Clear()
+		MSync.Modules.disabledModulesList:Clear()
+		AddTable(MSync.LocalSettings.EnabledModules,MSync.Modules.enabledModulesList)
+		AddTable(MSync.LocalSettings.DisabledModules,MSync.Modules.disabledModulesList)
+
+		MSync.Modules.enable.DoClick = function()
+			if not(MSync.Modules.disabledModulesList:GetSelected()[1]:GetValue(1)==nil)then
+				MSync.Modules.enabledModulesList:AddLine( MSync.Modules.disabledModulesList:GetSelected()[1]:GetValue(1))
+				MSync.Modules.disabledModulesList:RemoveLine(MSync.Modules.disabledModulesList:GetSelectedLine())
+			else
+				print("[MSync] ERROR: No line selected! (A3)")
+			end
+		end
+
+		MSync.Modules.disable.DoClick = function()
+			if not(MSync.Modules.enabledModulesList:GetSelected()[1]:GetValue(1)==nil)then
+				MSync.Modules.disabledModulesList:AddLine( MSync.Modules.enabledModulesList:GetSelected()[1]:GetValue(1))
+				MSync.Modules.enabledModulesList:RemoveLine(MSync.Modules.enabledModulesList:GetSelectedLine())
+			else
+				MSync.Chat(Color(255,0,0),"ERROR: No line selected! (A3)")
+			end
+		end
+
+	end
+end
+
+MSync.savebutton.DoClick = function()
+	if not(MSync.settingList:GetSelectedLine()==nil)then
+		if(MSync.settingList:GetSelected()[1]:GetValue(1)=="MySQL")then
+			MSync.LocalSettings.mysql ={
+				Host = MSync.MySQL.Host:GetText(),
+				Port = tonumber(MSync.MySQL.Port:GetText()),
+				Database = MSync.MySQL.Database:GetText(),
+				Username = MSync.MySQL.Username:GetText(),
+				Password = MSync.MySQL.Password:GetText()
+			}
+			MSync.LocalSettings.Servergroup = MSync.MySQL.Servergrp:GetText()
 			MSync.SendSettings()
-			MSync.Chat(Color(255,0,0),"No option selected! (A3)")
-		end
-	end
+		elseif(MSync.settingList:GetSelected()[1]:GetValue(1)=="MRSync")then
+			MSync.LocalSettings.mrsync.AllServerRanks = {}
+			MSync.LocalSettings.mrsync.IgnoredRanks = {}
 
-	MSync.resetbutton.DoClick = function()
-		MSync.LocalSettings = {
-			Servergroup = "Default",
-			EnabledModules = {
-				"MRSync"
+			for k, line in pairs( MSync.MRSync.IgnoreTable:GetLines()) do
+				if not(table.HasValue(MSync.LocalSettings.mrsync.IgnoredRanks,line:GetValue( 1 )))then
+					table.insert(MSync.LocalSettings.mrsync.IgnoredRanks, line:GetValue( 1 ))
+				end
+			end
+			for k, line in pairs( MSync.MRSync.AllServerTable:GetLines())  do
+				if not(table.HasValue(MSync.LocalSettings.mrsync.AllServerRanks,line:GetValue( 1 )))then
+					table.insert(MSync.LocalSettings.mrsync.AllServerRanks, line:GetValue( 1 ))
+				end
+			end
+			MSync.SendSettings()
+		elseif(MSync.settingList:GetSelected()[1]:GetValue(1)=="MBSync")then
+
+			MSync.SendSettings()
+		elseif(MSync.settingList:GetSelected()[1]:GetValue(1)=="Modules")then
+			MSync.LocalSettings.EnabledModules = {}
+			MSync.LocalSettings.DisabledModules = {}
+
+			for k, line in pairs( MSync.Modules.enabledModulesList:GetLines())  do
+				if not(table.HasValue(MSync.LocalSettings.EnabledModules,line:GetValue( 1 )))then
+					table.insert(MSync.LocalSettings.EnabledModules, line:GetValue( 1 ))
+				end
+			end
+			for k, line in pairs( MSync.Modules.disabledModulesList:GetLines())  do
+				if not(table.HasValue(MSync.LocalSettings.DisabledModules,line:GetValue( 1 )))then
+					table.insert(MSync.LocalSettings.DisabledModules, line:GetValue( 1 ))
+				end
+			end
+			MSync.SendSettings()
+		end
+	else
+		MSync.SendSettings()
+		MSync.Chat(Color(255,0,0),"No option selected! (A3)")
+	end
+end
+
+MSync.resetbutton.DoClick = function()
+	MSync.LocalSettings = {
+		Servergroup = "Default",
+		EnabledModules = {
+			"MRSync"
+		},
+		DisabledModules = {
+			"MBSync"
+		},
+		mysql = {
+			Host = "127.0.0.1",
+			Port = 3306,
+			Database = "",
+			Username = "root",
+			Password = ""
+		},
+		mrsync = {
+			AllServerRanks = {
+				"owner",
+				"superadmin",
+				"admin"
 			},
-			DisabledModules = {
-				"MBSync"
-			},
-			mysql = {
-				Host = "127.0.0.1",
-				Port = 3306,
-				Database = "",
-				Username = "root",
-				Password = ""
-			},
-			mrsync = {
-				AllServerRanks = {
-					"owner",
-					"superadmin",
-					"admin"
-				},
-				IgnoredRanks = {
-					"drp_donator",
-					"drp_admin"
-				}
+			IgnoredRanks = {
+				"drp_donator",
+				"drp_admin"
 			}
 		}
-		MSync.RefreshPanel()
-		MSync.Chat(Color(255,128,64),"Reset settings (A1)")
-	end
+	}
+	MSync.RefreshPanel()
+	MSync.Chat(Color(255,128,64),"Reset settings (A1)")
+end
 
-	MSync.refreshbutton.DoClick = function()
-		MSync.GetSettings()
-		MSync.Chat(Color(255,128,64),"Refreshing XGUI")
-	end
+MSync.refreshbutton.DoClick = function()
+	MSync.GetSettings()
+	MSync.Chat(Color(255,128,64),"Refreshing XGUI")
+end
 
 
-	/*MSync.Modules.enable.DoClick = function()
-		MSync.Modules.enabledModulesList:AddLine( MSync.Modules.disabledModulesList:GetSelectedLine():GetValue(1) )
-		MSync.Modules.disabledModulesList:RemoveLine(MSync.Modules.disabledModulesList:GetSelectedLine())
-	end
+--[[MSync.Modules.enable.DoClick = function()
+	MSync.Modules.enabledModulesList:AddLine( MSync.Modules.disabledModulesList:GetSelectedLine():GetValue(1) )
+	MSync.Modules.disabledModulesList:RemoveLine(MSync.Modules.disabledModulesList:GetSelectedLine())
+end
 
-	MSync.Modules.disable.DoClick = function()
-		MSync.Modules.disabledModulesList:AddLine( MSync.Modules.enabledModulesList:GetSelectedLine():GetValue(1) )
-		MSync.Modules.enabledModulesList:RemoveLine(MSync.Modules.disabledModulesList:GetSelectedLine())
-	end
-	*/
+MSync.Modules.disable.DoClick = function()
+	MSync.Modules.disabledModulesList:AddLine( MSync.Modules.enabledModulesList:GetSelectedLine():GetValue(1) )
+	MSync.Modules.enabledModulesList:RemoveLine(MSync.Modules.disabledModulesList:GetSelectedLine())
+end
+]]--
 
 xgui.addSettingModule( "MSync", MSync.back, "icon16/shield.png" )

--- a/lua/ulx/xgui/settings/cl_msync_gui.lua
+++ b/lua/ulx/xgui/settings/cl_msync_gui.lua
@@ -22,7 +22,7 @@ end
 		MSync.Modules.disabledModulesList:AddColumn( "Disabled Modules" )
 		MSync.Modules.enabledModulesList:SetMultiSelect( false )
 		MSync.Modules.disabledModulesList:SetMultiSelect( false )
-		MSync.Modules.DescriptionText = xlib.makelabel{ x=180, y=235, w=300, wordwrap=true, label="Description: To enable an module select the Module in the Disabled modules list and press '<-' to disable a Module select it in the Enabled Modules list and press '->'", parent=MSync.back }
+		MSync.Modules.DescriptionText = xlib.makelabel{ x=180, y=235, w=300, wordwrap=true, label="To enable a module, select the module in the Disabled modules list and press '<-'. To disable a module, select it in the Enabled Modules list and press '->'.", parent=MSync.back }
 	end
 
 	function MSync.MySQL.init()
@@ -39,7 +39,7 @@ end
 		MSync.MySQL.Database 		= xlib.maketextbox{ parent=MSync.back, x=165, y=225, w=160, h=25, disabled=false, visible=true}
 		MSync.MySQL.Servergrptext 	= xlib.makelabel{ x=165, y=255, label="Servergroup:", parent=MSync.back }
 		MSync.MySQL.Servergrp 		= xlib.maketextbox{ parent=MSync.back, x=165, y=270, w=160, h=25, disabled=false, visible=true}
-		MSync.MySQL.DescriptionText = xlib.makelabel{ x=350, y=10, w=170, wordwrap=true, label="Description: Set here your MySQL Settings.\n+HOST+ As Host set your SQL Providers Host IP.+PORT+ As Port set your MySQL Servers Port.\n+USERNAME+ As Username set your Databases Username to access the Database.\n+PASSWORD+ As Password set the Password for the Database User.\n+DATABASE+ As Database set the Sheme Name of your Database. \n+SERVERGROUP+ As servergroup set your Servers Group (Example: DarkRP or sandbox)", parent=MSync.back }
+		MSync.MySQL.DescriptionText = xlib.makelabel{ x=350, y=10, w=170, wordwrap=true, label="Set your MySQL settings here.\nHOST: Hostname or IP address of the SQL server.\nPORT: Port of the MySQL server.\nUSERNAME: Username for the access to the database.\nPASSWORD: Password for the MySQL user.\nDATABASE: Name of the MySQL database to use.\nSERVERGROUP: Name of the server group this server belongs to (for example DarkRP or sandbox).", parent=MSync.back }
 		
 		/* Currently not Working! Stay tuned for Updates!
 		MSync.MySQL.connectText		= xlib.makelabel{ x=360, y=265, label="Status: Unknown", parent=MSync.back }
@@ -68,11 +68,11 @@ end
 		MSync.MRSync.IgnoreTextBox			= xlib.maketextbox{ parent=MSync.back, x=160, y=220, w=120, h=25, disabled=false, visible=true}
 		MSync.MRSync.AllServerTextBox		= xlib.maketextbox{ parent=MSync.back, x=320, y=220, w=120, h=25, disabled=false, visible=true}
 		
-		MSync.MRSync.Descriptiontext 		= xlib.makelabel{ x=475, y=30, w=100, wordwrap=true, label="Description: Ignored Ranks: this is the list of ranks which are not be saved in the mysql table.\n All Server Ranks: this are the ranks which ignore the Servergroup and are synced throught all servers", parent=MSync.back }
-		MSync.MRSync.Descriptiontext2 		= xlib.makelabel{ x=160, y=250, w=340, wordwrap=true, label="Description: Enter the rank and press '+' to add it to the list. To remove select in the table the entry you want to remove and press '-'", parent=MSync.back }
+		MSync.MRSync.Descriptiontext 		= xlib.makelabel{ x=475, y=30, w=100, wordwrap=true, label="Ignored ranks: This is a list of ranks which are not going to be saved in the MySQL table.\nAll servers ranks: These are ranks which ignore the Servergroup and are synced across all servers", parent=MSync.back }
+		MSync.MRSync.Descriptiontext2 		= xlib.makelabel{ x=160, y=250, w=340, wordwrap=true, label="Description: Enter the rank and press '+' to add it to the list. To remove an entry, select it in the table and press '-'.", parent=MSync.back }
 		
-		MSync.MRSync.IgnoreTable:AddColumn( "Ignored Ranks" ) 
-		MSync.MRSync.AllServerTable:AddColumn( "All Server Ranks" ) 
+		MSync.MRSync.IgnoreTable:AddColumn( "Ignored ranks" ) 
+		MSync.MRSync.AllServerTable:AddColumn( "All servers ranks" ) 
 		MSync.MRSync.IgnoreTable:SetMultiSelect( false )
 		MSync.MRSync.AllServerTable:SetMultiSelect( false )
 	end
@@ -82,12 +82,12 @@ end
 		
 		MSync.MBSync.Table:AddColumn( "Name/SteamID" ) 
 		MSync.MBSync.Table:AddColumn( "Banned by" ) 
-		MSync.MBSync.Table:AddColumn( "Unban Date" ) 
+		MSync.MBSync.Table:AddColumn( "Unban date" ) 
 		MSync.MBSync.Table:AddColumn( "Reason" ) 
 		MSync.MBSync.SearchBox			= xlib.maketextbox{ parent=MSync.back, x=160, y=5, w=150, h=25, disabled=false, visible=true}
 		MSync.MBSync.Sync				= xlib.makebutton{ parent=MSync.back, x=370, y=5, w=50, h=25, label="Sync", disabled=false }
 		MSync.MBSync.SearchButton		= xlib.makebutton{ parent=MSync.back, x=315, y=5, w=50, h=25, label="Search", disabled=false }
-		MSync.MBSync.Description		= xlib.makelabel{ x=425, y=5, w=150, wordwrap=true, label="Description: You need to press 'Sync' to get the bans.", parent=MSync.back }
+		MSync.MBSync.Description		= xlib.makelabel{ x=425, y=5, w=150, wordwrap=true, label="Press 'Sync' to retrieve the bans.", parent=MSync.back }
 
 	end
 
@@ -144,7 +144,7 @@ end
 				if not(MSync.MRSync.AllServerTable:GetSelected()[1]:GetValue(1)==nil)then
 					MSync.MRSync.AllServerTable:RemoveLine(MSync.MRSync.AllServerTable:GetSelectedLine())	
 				else
-					MSync.Chat(Color(255,0,0),"ERROR: No Rank Selected! (A3)")
+					MSync.Chat(Color(255,0,0),"ERROR: No rank selected! (A3)")
 				end
 			end
 			
@@ -157,7 +157,7 @@ end
 				if not(MSync.MRSync.IgnoreTable:GetSelected()[1]:GetValue(1)==nil)then
 					MSync.MRSync.IgnoreTable:RemoveLine(MSync.MRSync.IgnoreTable:GetSelectedLine())	
 				else
-					MSync.Chat(Color(255,0,0),"ERROR: No Rank Selected! (A3)")
+					MSync.Chat(Color(255,0,0),"ERROR: No rank selected! (A3)")
 				end
 			end
 		elseif line:GetValue(1) == "MBSync" then
@@ -182,7 +182,7 @@ end
 			MSync.MBSync.Table.OnRowRightClick = function( self, LineID, line )
 				local menu = DermaMenu()
 				menu:SetSkin(xgui.settings.skin)
-				/*menu:AddOption( "Edit Ban...", function()
+				/*menu:AddOption( "Edit ban...", function()
 					if not line:IsValid() then return end
 					xgui.ShowBanWindow( nil, line:GetValue( 5 ), nil, true, xgui.data.bans.cache[LineID] )
 				end )*/
@@ -209,7 +209,7 @@ end
 					MSync.Modules.enabledModulesList:AddLine( MSync.Modules.disabledModulesList:GetSelected()[1]:GetValue(1))
 					MSync.Modules.disabledModulesList:RemoveLine(MSync.Modules.disabledModulesList:GetSelectedLine())
 				else
-					print("[MSync] ERROR: No line Selected! (A3)")
+					print("[MSync] ERROR: No line selected! (A3)")
 				end
 			end
 
@@ -218,7 +218,7 @@ end
 					MSync.Modules.disabledModulesList:AddLine( MSync.Modules.enabledModulesList:GetSelected()[1]:GetValue(1))
 					MSync.Modules.enabledModulesList:RemoveLine(MSync.Modules.enabledModulesList:GetSelectedLine())
 				else
-					MSync.Chat(Color(255,0,0),"ERROR: No line Selected! (A3)")
+					MSync.Chat(Color(255,0,0),"ERROR: No line selected! (A3)")
 				end
 			end
 		
@@ -273,7 +273,7 @@ end
 			end
 		else
 			MSync.SendSettings()
-			MSync.Chat(Color(255,0,0),"No Option Selected! (A3)")
+			MSync.Chat(Color(255,0,0),"No option selected! (A3)")
 		end
 	end
 
@@ -306,7 +306,7 @@ end
 			}
 		}
 		MSync.RefreshPanel()
-		MSync.Chat(Color(255,128,64),"Reset Settings (A1)")
+		MSync.Chat(Color(255,128,64),"Reset settings (A1)")
 	end
 
 	MSync.refreshbutton.DoClick = function()

--- a/readme.md
+++ b/readme.md
@@ -1,0 +1,78 @@
+[h1]This is the all around solution for multi-server communities[/h1]
+[h1]This addon syncs Ranks and Bans (Currently: More features will be added)[/h1]
+
+[b]MSync[/b]
+
+[b]M[/b]ySQL
+[b]Sync[/b]hronisation
+
+Join my Website: https://Aperture-Hosting.de - An forum for developers and support all around GMod
+
+[h1]##Features##[/h1]
+
+[h1]MSync:[/h1] ( MySQL Synchronisation )
+
+MSync is the all around solution for server synchronisation.
+
+- In Game Configuration via XGUI
+- Settings Saveable
+- to get the current version enter: 'msync_version' into the server console
+- Even with allowCSlua the People can't get the Settings table without Permission. Who tryes to 'force get it' gets kicked
+
+[h1]MRSync:[/h1] ( MySQL Rank Synchronisation )
+
+MRSync will keep your staff team synchronised with possibility to have 2 staff teams.
+- Saving Ranks on: ClientDisconnect and ServerStop
+- Ability to set Ranks that get Synced throught all servers
+- Ability to set Ranks as 'ignored' to make them not saving in the database.
+
+[h1]MBSync:[/h1] ( MySQL Ban Synchronisation )
+
+MBSync is the Free solution for synchronised bans. If you ban someone hes banned on your server network.
+- ulx checkban <steamid> command
+- Overwrites "ulx ban","ulx banid" and "ulx unban"
+- an Ban message which says all the needed infos for an unban request
+
+[h1]##Requirements##[/h1]
+
+1. MySQLoo ( http://facepunch.hatt.co/showthread.php?t=1357773 )
+2. ULX and ULib ( http://ulyssesmod.net/downloads.php )
+3. an MySQL Database
+
+[h1]##Basic Setup##[/h1]
+
+First you need to Install MySQLoo which can be found here: http://facepunch.hatt.co/showthread.php?t=1357773
+An exelent instruction of how to Install it can be found here: https://help.serenityservers.net/index.php?title=Garrysmod:How_to_install_mysqloo_or_tmysql
+
+After that you need to setup a database for your ranks.
+1. Create a user for MRSync with a complex password
+2. Add a database scheme to it for MRSync.
+3. Setup your settings in-game
+4. Restart your server
+5. If it says [i] [MSync] Connected to Database [/i] you are done. 
+
+[h1]#Planned features#[/h1]
+
+- Webpanel
+- MWS ( MySQL Warning System )
+- Rank backups
+- MPSync ( MySQL Permission Synchronisation )
+- MUSync ( MySQL Utime Synchronisation )
+
+[h1]#Support/Bugs#[/h1]
+
+Please use my support ticked system at: https://support.aperture-hosting.de/
+Or mail me under: Webmaster@Rainbow-Dash.com
+
+[h1]#Other#[/h1]
+
+Join my Website to talk to other Programmers and for help with your stuff:
+https://Aperture-Hosting.de/ (In Setup)
+
+Follow me on GitHub: https://github.com/captain1242
+
+Communities I am Playing on:
+
+Instant-Roleplay - https://Instant-Roleplay.com/
+Cloudsdale Gaming - http://CloudsdaleGaming.com/
+X-Coder Buildserver

--- a/readme.md
+++ b/readme.md
@@ -1,77 +1,71 @@
-[h1]This is the all around solution for multi-server communities[/h1]
-[h1]This addon syncs Ranks and Bans (Currently: More features will be added)[/h1]
+# MSync (**M**ySQL **Sync**hronisation)
+#### This is the all around solution for multi-server communities
+##### This addon syncs ranks and bans (more features will be added)
 
-[b]MSync[/b]
+Join my website: https://Aperture-Hosting.de - a forum for developers and support all around GMod
 
-[b]M[/b]ySQL
-[b]Sync[/b]hronisation
+# Features
 
-Join my Website: https://Aperture-Hosting.de - An forum for developers and support all around GMod
-
-[h1]##Features##[/h1]
-
-[h1]MSync:[/h1] ( MySQL Synchronisation )
+## MSync: (MySQL Synchronisation)
 
 MSync is the all around solution for server synchronisation.
 
-- In Game Configuration via XGUI
-- Settings Saveable
-- to get the current version enter: 'msync_version' into the server console
-- Even with allowCSlua the People can't get the Settings table without Permission. Who tryes to 'force get it' gets kicked
+- In-game configuration via XGUI
+- Settings saveable
+- To get the current version, enter `msync_version` in the server console
+- Even with `sv_allowcslua` on, players cannot get the settings table without permission. Those who try to 'force get it' get kicked.
 
-[h1]MRSync:[/h1] ( MySQL Rank Synchronisation )
+### MRSync: (MySQL Rank Synchronisation)
 
 MRSync will keep your staff team synchronised with possibility to have 2 staff teams.
-- Saving Ranks on: ClientDisconnect and ServerStop
-- Ability to set Ranks that get Synced throught all servers
-- Ability to set Ranks as 'ignored' to make them not saving in the database.
+- Saving ranks on `PlayerDisconnected` and `ShutDown`
+- Ability to set ranks that get synced through all servers
+- Ability to set ranks as "ignored" to make them not saved in the database.
 
-[h1]MBSync:[/h1] ( MySQL Ban Synchronisation )
+### MBSync: (MySQL Ban Synchronisation)
 
-MBSync is the Free solution for synchronised bans. If you ban someone hes banned on your server network.
-- ulx checkban <steamid> command
-- Overwrites "ulx ban","ulx banid" and "ulx unban"
-- an Ban message which says all the needed infos for an unban request
+MBSync is a free solution for bans synchronisation. If you ban someone, they are banned on all your servers.
+- `ulx checkban <steamid>` command
+- Overwrites `ulx ban`, `ulx banid` and `ulx unban`
+- a configurable ban message which provides all the information needed for a ban appeal
 
-[h1]##Requirements##[/h1]
-
+# Requirements
 1. MySQLoo ( http://facepunch.hatt.co/showthread.php?t=1357773 )
 2. ULX and ULib ( http://ulyssesmod.net/downloads.php )
-3. an MySQL Database
+3. a MySQL Database
 
-[h1]##Basic Setup##[/h1]
+# Basic Setup
 
-First you need to Install MySQLoo which can be found here: http://facepunch.hatt.co/showthread.php?t=1357773
+First you need to install MySQLoo which can be found here: https://facepunch.com/showthread.php?t=1515853
 An exelent instruction of how to Install it can be found here: https://help.serenityservers.net/index.php?title=Garrysmod:How_to_install_mysqloo_or_tmysql
 
 After that you need to setup a database for your ranks.
-1. Create a user for MRSync with a complex password
-2. Add a database scheme to it for MRSync.
-3. Setup your settings in-game
-4. Restart your server
-5. If it says [i] [MSync] Connected to Database [/i] you are done. 
+1. Create a user for MSync with a complex password.
+2. Add a database scheme to it for MSync.
+3. Enter you DB settings in-game.
+4. Restart your server.
+5. If it says `[MSync] Connected to database`, you are done.
 
-[h1]#Planned features#[/h1]
+# Planned features
 
 - Webpanel
-- MWS ( MySQL Warning System )
+- MWS (MySQL Warning System)
 - Rank backups
-- MPSync ( MySQL Permission Synchronisation )
-- MUSync ( MySQL Utime Synchronisation )
+- MPSync (MySQL Permission Synchronisation)
+- MUSync (MySQL Utime Synchronisation)
 
-[h1]#Support/Bugs#[/h1]
+# Support/Bugs
 
 Please use my support ticked system at: https://support.aperture-hosting.de/
 Or mail me under: Webmaster@Rainbow-Dash.com
 
-[h1]#Other#[/h1]
-
-Join my Website to talk to other Programmers and for help with your stuff:
-https://Aperture-Hosting.de/ (In Setup)
+# Other
+Join my website to talk to other programmers and for help with your stuff:
+https://Aperture-Hosting.de/ (work in progress)
 
 Follow me on GitHub: https://github.com/captain1242
 
-Communities I am Playing on:
+Communities I am playing on:
 
 Instant-Roleplay - https://Instant-Roleplay.com/
 Cloudsdale Gaming - http://CloudsdaleGaming.com/


### PR DESCRIPTION
- Put table names in variables so they can be easily changed for the whole addon

- Changed standard SQL queries with escaping to prepared queries

- Completely revamped the database structure:- Put table names in variables so they can be easily changed for the whole addon

- Changed standard SQL queries with escaping to prepared queries

- Completely revamped the database structure:
	- Renamed admin to staff (since not all staff members are admins) and nickname to just name (for no good reason)
	- Added column for staff SteamID (since names can change often and it also lets other systems find all bans performed by a specific staff member)
	- Expanded allowed length of names to 32 and reasons to 255 (because names can be up to 32 characters and reasons are capped by the internal working)
	- Changed ban_date and duration to unsigned integers (since neither can ever be negative + it doubles the maximum value)
	- Removed unique key on player's SteamID, so the table can hold multiple bans per player to also work as a ban history
	- Added index on SteamID for quick SELECTs on them (since that is the column that will be primarily used for selecting)
	- Removed NOT NULL from name and staff SteamID:
		- When ulx banid is used, the name of the player is unknown - it's better to store actual NULL than some default text like "NULL" or "Unknown"
		- When banning is done through server console, the calling player is not a valid entity, so it doesn't have any SteamID. "(Console)" is used as the staff name in such cases, while staff SteamID is NULL.

- Implemented a simple system to do database upgrades when switching to new version of the addon:
	- Added a new settings variable called DBVersion. When the addon is first installed, the DBVersion is set to 0 by default. When the addon is being loaded, it checks the current DBVersion and performs all the queries that were made for the versions lower than the current one to update the database to a newer version, then stores that version in the settings. After the initialization, if everything went well, the DBVersion matches the DB version of the addon and when a new version is installed, only the query to update it from the last version to the next one is done.

- Eradicated calls to "wait()" MySQLoo function where possible (because it stops the whole server until the query finishes, which may take a long time if there is any kind of problem with the SQL server)

- Completely revamped all the commands (ulx ban, ulx banid, ulx unban, ulx checkban) to work correctly with the table storing multiple bans:
	- Checkban simply checks if there is any ban that has duration of 0 (permanent) or exceeding the current timestamp when added to the date and time of ban.
	- When adding a ban, any ban that is still valid (same as checkban) has duration changed so that the ban ends right at this moment, then the new ban is added. This ensures there is always only one ban per player that is valid at a time and not more of them that overlap. The whole action is performed in a transaction, to ensure atomicity.
	- When removing a ban, it is checked if there is a valid ban (same way as checkban does), then it has its duration set to current datetime or says the player isn't banned, so it cannot be unbanned.

- Fixed all the commands to be also usable from the server console (when calling player is not a valid entity)

- Changed the "You are banned!" window:
	- Every code showing the window uses the same function to create the same content everywhere now (when being kicked, when being banned before joining, when being banned during joining...) as opposed to subtle differences before
	- The window shows information about where to appeal the ban
	- Changed the format of date and time of ban being displayed to %d/%m/%Y %H:%M (since it's the more conventional way here)
	- Made a function to convert seconds to human-friendly text:
		- The window shows the time until the ban is lifted in human-friendly way (for example: 3 days, 8 hours, 23 minutes, 52 seconds)

- Changed all the previously existing comments to use -- or --[[]]-- notation instead of C-style // (-- are actual LUA comments, while // only work in Gmod LUA and many IDEs which can't handle Gmod Lua will complain about them being a syntax error)

- Fixed typos and spelling mistakes all over the code

- Changed code style to better match the LUA code style conventions

- Changed readme.md to proper Markdown syntax
	- Renamed admin to staff (since not all staff members are admins) and nickname to just name (for no good reason)
	- Added column for staff SteamID (since names can change often and it also lets other systems find all bans performed by a specific staff member)
	- Expanded allowed length of names to 32 and reasons to 255 (because names can be up to 32 characters and reasons are capped by the internal working)
	- Changed ban_date and duration to unsigned integers (since neither can ever be negative + it doubles the maximum value)
	- Removed unique key on player's SteamID, so the table can hold multiple bans per player to also work as a ban history
	- Added index on SteamID for quick SELECTs on them (since that is the column that will be primarily used for selecting)
	- Removed NOT NULL from name and staff SteamID:
		- When ulx banid is used, the name of the player is unknown - it's better to store actual NULL than some default text like "NULL" or "Unknown"
		- When banning is done through server console, the calling player is not a valid entity, so it doesn't have any SteamID. "(Console)" is used as the staff name in such cases, while staff SteamID is NULL.

- Implemented a simple system to do database upgrades when switching to new version of the addon:
	- Added a new settings variable called DBVersion. When the addon is first installed, the DBVersion is set to 0 by default. When the addon is being loaded, it checks the current DBVersion and performs all the queries that were made for the versions lower than the current one to update the database to a newer version, then stores that version in the settings. After the initialization, if everything went well, the DBVersion matches the DB version of the addon and when a new version is installed, only the query to update it from the last version to the next one is done.

- Eradicated calls to "wait()" MySQLoo function where possible (because it stops the whole server until the query finishes, which may take a long time if there is any kind of problem with the SQL server)

- Completely revamped all the commands (ulx ban, ulx banid, ulx unban, ulx checkban) to work correctly with the table storing multiple bans:
	- Checkban simply checks if there is any ban that has duration of 0 (permanent) or exceeding the current timestamp when added to the date and time of ban.
	- When adding a ban, any ban that is still valid (same as checkban) has duration changed so that the ban ends right at this moment, then the new ban is added. This ensures there is always only one ban per player that is valid at a time and not more of them that overlap. The whole action is performed in a transaction, to ensure atomicity.
	- When removing a ban, it is checked if there is a valid ban (same way as checkban does), then it has its duration set to current datetime or says the player isn't banned, so it cannot be unbanned.

- Fixed all the commands to be also usable from the server console (when calling player is not a valid entity)

- Changed the "You are banned!" window:
	- Every code showing the window uses the same function to create the same content everywhere now (when being kicked, when being banned before joining, when being banned during joining...) as opposed to subtle differences before
	- The window shows information about where to appeal the ban
	- Changed the format of date and time of ban being displayed to %d/%m/%Y %H:%M (since it's the more conventional way here)
	- Made a function to convert seconds to human-friendly text:
		- The window shows the time until the ban is lifted in human-friendly way (for example: 3 days, 8 hours, 23 minutes, 52 seconds)

- Changed all the previously existing comments to use -- or --[[]]-- notation instead of C-style // (-- are actual LUA comments, while // only work in Gmod LUA and many IDEs which can't handle Gmod Lua will complain about them being a syntax error)

- Fixed typos and spelling mistakes all over the code

- Changed code style to better match the LUA code style conventions

- Changed readme.md to proper Markdown syntax